### PR TITLE
Html report, settings XML, options screen, dedicated UI for CR Maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
-# Added for this project
-Todo.txt
-
 # User-specific files
 *.rsuser
 *.suo

--- a/Change notes.md
+++ b/Change notes.md
@@ -1,5 +1,8 @@
 # Compatibility Report
 
+### Version 0.7.6
+* Support for fake subscriptions, for testing
+
 ### Version 0.7.5
 * Minor code improvements
 * Improved logging

--- a/Change notes.md
+++ b/Change notes.md
@@ -2,6 +2,7 @@
 
 ### Version 0.7.6
 * Support for fake subscriptions, for testing
+* Support for one-time actions of the Updater
 
 ### Version 0.7.5
 * Minor code improvements

--- a/Change notes.md
+++ b/Change notes.md
@@ -1,5 +1,10 @@
 # Compatibility Report
 
+### Version 0.8.0
+* HTML report generation
+* Options screen with basic info about catalog state and lots of configurable settings
+* Updater: a lot of code improvements and changes, created dedicated UI for easier maintenance
+
 ### Version 0.7.6
 * Support for fake subscriptions, for testing
 * Support for one-time actions of the Updater

--- a/CompatibilityReport.sln
+++ b/CompatibilityReport.sln
@@ -22,10 +22,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E43B190E-C881-4B71-AF47-D50D978D874C}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{E43B190E-C881-4B71-AF47-D50D978D874C}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{E43B190E-C881-4B71-AF47-D50D978D874C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E43B190E-C881-4B71-AF47-D50D978D874C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E43B190E-C881-4B71-AF47-D50D978D874C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E43B190E-C881-4B71-AF47-D50D978D874C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CompatibilityReport/CatalogData/Catalog.cs
+++ b/CompatibilityReport/CatalogData/Catalog.cs
@@ -56,6 +56,7 @@ namespace CompatibilityReport.CatalogData
         private readonly Dictionary<string, List<ulong>> subscriptionNameIndex = new Dictionary<string, List<ulong>>();
         private readonly Dictionary<ulong, List<Compatibility>> subscriptionCompatibilityIndex = new Dictionary<ulong, List<Compatibility>>();
 
+        [XmlIgnore] public DateTime Downloaded { get; private set; }
         [XmlIgnore] public int ReviewedModCount { get; private set; }
         [XmlIgnore] public int ReviewedSubscriptionCount { get; private set; }
         [XmlIgnore] public int LocalSubscriptionCount { get; private set; }
@@ -65,6 +66,7 @@ namespace CompatibilityReport.CatalogData
 
         public static bool DownloadStarted { get; private set; }
         public static bool DownloadSuccessful { get; private set; }
+        public static string SettingsUIText { get; private set; } = "unknown, catalog not loaded yet."; 
 
 
         /// <summary>Default constructor for deserialization and catalog creation.</summary>
@@ -690,6 +692,8 @@ namespace CompatibilityReport.CatalogData
                 return null;
             }
 
+            loadedCatalog.Downloaded = File.GetLastWriteTime(fullPath);
+
             return loadedCatalog;
         }
 
@@ -711,6 +715,9 @@ namespace CompatibilityReport.CatalogData
             if (newestCatalog != null)
             {
                 newestCatalog.CreateIndexes();
+
+                SettingsUIText = $"<color { ModSettings.SettingsUIColor }>{ newestCatalog.VersionString() }</color>, created on { newestCatalog.Updated:d MMM yyyy}" +
+                    $", downloaded on { newestCatalog.Downloaded:d MMM yyyy}";
 
                 Logger.Log($"Using catalog { newestCatalog.VersionString() }, created on { newestCatalog.Updated.ToLocalTime().ToLongDateString() }. " +
                     $"Catalog contains { newestCatalog.ReviewedModCount } reviewed mods with { newestCatalog.Compatibilities.Count } compatibilities and " +

--- a/CompatibilityReport/CatalogData/Mod.cs
+++ b/CompatibilityReport/CatalogData/Mod.cs
@@ -304,13 +304,20 @@ namespace CompatibilityReport.CatalogData
         {
             string disabledPrefix = IsDisabled ? "[Disabled] " : "";
 
-            string idString = (SteamID > ModSettings.HighestFakeID) ? $"[Steam ID { SteamID, 10 }]" :
-                ModSettings.BuiltinMods.ContainsValue(SteamID) ? $"[built-in mod{ (hideFakeID ? "" : $" { SteamID }") }]" :
-                $"[local mod{ (hideFakeID ? "" : $" { SteamID }") }]";
+            string idString = IdString(hideFakeID);
 
             string name = !cutOff ? Name : Toolkit.CutOff(Name, ModSettings.TextReportWidth - idString.Length - 1 - disabledPrefix.Length);
 
             return nameFirst ? $"{ disabledPrefix }{ name } { idString }" : $"{ disabledPrefix }{ idString } { name }";
+        }
+
+        public string IdString(bool hideFakeID = false)
+        {
+            return (SteamID > ModSettings.HighestFakeID) 
+                ? $"[Steam ID { SteamID, 10 }]"
+                : ModSettings.BuiltinMods.ContainsValue(SteamID)
+                    ? $"[built-in mod{ (hideFakeID ? "" : $" { SteamID }") }]"
+                    : $"[local mod{ (hideFakeID ? "" : $" { SteamID }") }]";
         }
     }
 }

--- a/CompatibilityReport/CompatibilityReport.cs
+++ b/CompatibilityReport/CompatibilityReport.cs
@@ -1,7 +1,11 @@
 ﻿using UnityEngine.SceneManagement;
 using ICities;
+using ColossalFramework.UI;
 using CompatibilityReport.Util;
 using CompatibilityReport.Reporter;
+
+// This class uses code snippets from the Settings class from Loading Screen Mod by thale5:
+// https://github.com/thale5/LSM/blob/master/LoadingScreenMod/Settings.cs
 
 namespace CompatibilityReport
 {
@@ -26,10 +30,117 @@ namespace CompatibilityReport
 
             Report.Create(scene);
 
-            UIHelperBase modOptions = helper.AddGroup(ModSettings.ModName);
+            // Todo 0.8 Create Mod Options UI and xml file. Remove dummy vars.
+            int dummy = 0;
+            bool settingsVisible = false;
 
-            modOptions.AddGroup("The mod options are not implemented yet.");
-            //Todo 0.8 Create Settings UI.
+            UIHelperBase group;
+            UIComponent container;
+            UIPanel panel;
+            UIButton button1, button2;
+            UIDropDown dropdown;
+            UILabel label;
+
+            group = helper.AddGroup("Report options:");
+            panel = (group as UIHelper).self as UIPanel;
+
+            // Todo 0.8 Remove temporary 'not implemented text.
+            label = panel.AddUIComponent<UILabel>();
+            label.processMarkup = true;
+            label.text = "<color #FF0000>THE MOD OPTIONS ARE NOT FULLY IMPLEMENTED YET.</color>";
+            group.AddSpace(20);
+
+            label = panel.AddUIComponent<UILabel>();
+            label.text = "Report path:";
+            label.textScale = 1.1f;
+            label = panel.AddUIComponent<UILabel>();
+            label.processMarkup = true;
+            label.text = $"<color { ModSettings.SettingsUIColor }>{ Toolkit.Privacy(ModSettings.ReportPath) }</color>";
+            label.textScale = 0.9f;
+            group.AddSpace(5);
+
+            button1 = group.AddButton("Change path", () => dummy++) as UIButton;
+            button1.isVisible = settingsVisible;    // Todo 0.8 Remove this.
+            button2 = group.AddButton("Reset path to default", () => dummy++) as UIButton;
+            button2.isVisible = settingsVisible;    // Todo 0.8 Remove this.
+            container = button1.parent;
+            panel = container.AddUIComponent<UIPanel>();
+            panel.width = container.width;
+            panel.height = button1.height;
+            button1.AlignTo(panel, UIAlignAnchor.TopLeft);
+            button2.AlignTo(panel, UIAlignAnchor.TopLeft);
+            button2.relativePosition += new UnityEngine.Vector3(button1.width + 10, 0);
+            group.AddSpace(10);
+
+            dropdown = group.AddDropdown("Report type: ", new string[] { "text" /*, "html", "text and html" */ }, 0, (int _) => { }) as UIDropDown; // Todo 0.8 Remove /* */
+            dropdown.width = 180f;
+            container = dropdown.parent;
+            panel = container.AddUIComponent<UIPanel>();
+            panel.width = container.width;
+            panel.height = dropdown.height;
+            button1 = group.AddButton("Open report(s)", () => dummy++) as UIButton;
+            button1.isVisible = settingsVisible;    // Todo 0.8 Remove this.
+            button2 = group.AddButton("Generate report(s)", () => dummy++) as UIButton;
+            button2.isVisible = settingsVisible;    // Todo 0.8 Remove this.
+            button1.AlignTo(panel, UIAlignAnchor.TopLeft);
+            button1.relativePosition += new UnityEngine.Vector3(dropdown.width + 30, -button1.height);
+            button2.AlignTo(panel, UIAlignAnchor.TopLeft);
+            button2.relativePosition += new UnityEngine.Vector3(dropdown.width + 30 + button1.width + 10, -button1.height);
+
+            group = helper.AddGroup("Catalog options:");
+            panel = (group as UIHelper).self as UIPanel;
+
+            label = panel.AddUIComponent<UILabel>();
+            label.processMarkup = true;
+            label.text = $"Catalog version: { CatalogData.Catalog.SettingsUIText }";
+            label.textScale = 1.1f;
+            group.AddSpace(10);
+            
+            dropdown = group.AddDropdown("Download: ",  // Todo 0.8 Remove /* */
+                new string[] { "Every game start", /* "Once per day", "Once a week", "Never (on-demand only) - not recommended!" */ }, 0, (int _) => { }) as UIDropDown;
+            dropdown.width = 290f;
+            container = dropdown.parent;
+            panel = container.AddUIComponent<UIPanel>();
+            panel.width = container.width;
+            panel.height = dropdown.height;
+            button1 = group.AddButton("Download now", () => dummy++) as UIButton;
+            button1.isVisible = settingsVisible;    // Todo 0.8 Remove this.
+            button1.AlignTo(panel, UIAlignAnchor.TopLeft);
+            button1.relativePosition += new UnityEngine.Vector3(dropdown.width + 30, -button1.height);
+
+            group = helper.AddGroup("Advanced options:");
+            panel = (group as UIHelper).self as UIPanel;
+
+            label = panel.AddUIComponent<UILabel>();
+            label.processMarkup = true;
+            label.text = $"Mod version: <color { ModSettings.SettingsUIColor }>{ ModSettings.FullVersion }</color>";
+            label.textScale = 1.1f;
+
+            // Todo 0.8 Activate checkboxes and button
+            // group.AddCheckbox("Show source URL in report", false, (bool _) => { });
+            // group.AddCheckbox("Show download date/time of mods in report", false, (bool _) => { });
+            // group.AddCheckbox("Debug logging", false, (bool _) => { });
+            group.AddSpace(10);
+            
+            // group.AddButton("Ignore selected incompatibilities", () => dummy++);
+
+            helper.AddButton("Reset all settings", () => dummy++);
+
+            /* OLD FIELDS, NO LONGER USED:
+
+                UITextField textField = group.AddTextfield("Report path:", Toolkit.Privacy(ModSettings.ReportPath), (string _) => { }) as UITextField;
+                textField.width = 650f;
+                textField.textScale = 0.8f;
+                textField.readOnly = true;
+
+                UIHelper subGroup = group.AddGroup(" ") as UIHelper;
+                var panel = subGroup.self as UIPanel;
+                panel.autoLayoutDirection = LayoutDirection.Horizontal;
+                panel.autoLayoutPadding = new UnityEngine.RectOffset(5, 5, 0, 0);
+                subGroup.AddButton("Open text report", () => dummy++);
+                subGroup.AddButton("Open HTML report", () => dummy++);
+                subGroup.AddButton("Generate new report", () => dummy++);
+            */
         }
     }
 }

--- a/CompatibilityReport/CompatibilityReport.cs
+++ b/CompatibilityReport/CompatibilityReport.cs
@@ -1,146 +1,40 @@
-﻿using UnityEngine.SceneManagement;
-using ICities;
-using ColossalFramework.UI;
+﻿using CompatibilityReport.Settings;
+using CompatibilityReport.UI;
 using CompatibilityReport.Util;
-using CompatibilityReport.Reporter;
+using ICities;
+using JetBrains.Annotations;
 
 // This class uses code snippets from the Settings class from Loading Screen Mod by thale5:
 // https://github.com/thale5/LSM/blob/master/LoadingScreenMod/Settings.cs
 
 namespace CompatibilityReport
 {
+    [UsedImplicitly]
     public class CompatibilityReport : IUserMod
     {
         public string Name { get; } = ModSettings.IUserModName;
         public string Description { get; } = ModSettings.IUserModDescription;
 
+        [UsedImplicitly]
+        public void OnEnabled()
+        {
+            GlobalConfig.Ensure();   
+        }
+
+        [UsedImplicitly]
+        public void OnDisabled()
+        {
+            SettingsManager.CleanupEvents();
+            Logger.CloseDebugLog();
+        }
 
         /// <summary>Start the Updater when enabled and the Reporter when called in the correct scene. Also opens the settings UI.</summary>
         /// <remarks>Called at the end of loading the game to the main menu (scene IntroScreen), when all subscriptions will be available. 
         ///          Called again when loading a map (scene Game), and presumably when opening the mod options.</remarks>
+        [UsedImplicitly]
         public void OnSettingsUI(UIHelperBase helper)
         {
-            string scene = SceneManager.GetActiveScene().name;
-            Logger.Log($"OnSettingsUI called in scene { scene }.", Logger.Debug);
-
-            if (ModSettings.UpdaterAvailable)
-            {
-                Updater.CatalogUpdater.Start();
-            }
-
-            Report.Create(scene);
-
-            // Todo 0.8 Create Mod Options UI and xml file. Remove dummy vars.
-            int dummy = 0;
-            bool settingsVisible = false;
-
-            UIHelperBase group;
-            UIComponent container;
-            UIPanel panel;
-            UIButton button1, button2;
-            UIDropDown dropdown;
-            UILabel label;
-
-            group = helper.AddGroup("Report options:");
-            panel = (group as UIHelper).self as UIPanel;
-
-            // Todo 0.8 Remove temporary 'not implemented text.
-            label = panel.AddUIComponent<UILabel>();
-            label.processMarkup = true;
-            label.text = "<color #FF0000>THE MOD OPTIONS ARE NOT FULLY IMPLEMENTED YET.</color>";
-            group.AddSpace(20);
-
-            label = panel.AddUIComponent<UILabel>();
-            label.text = "Report path:";
-            label.textScale = 1.1f;
-            label = panel.AddUIComponent<UILabel>();
-            label.processMarkup = true;
-            label.text = $"<color { ModSettings.SettingsUIColor }>{ Toolkit.Privacy(ModSettings.ReportPath) }</color>";
-            label.textScale = 0.9f;
-            group.AddSpace(5);
-
-            button1 = group.AddButton("Change path", () => dummy++) as UIButton;
-            button1.isVisible = settingsVisible;    // Todo 0.8 Remove this.
-            button2 = group.AddButton("Reset path to default", () => dummy++) as UIButton;
-            button2.isVisible = settingsVisible;    // Todo 0.8 Remove this.
-            container = button1.parent;
-            panel = container.AddUIComponent<UIPanel>();
-            panel.width = container.width;
-            panel.height = button1.height;
-            button1.AlignTo(panel, UIAlignAnchor.TopLeft);
-            button2.AlignTo(panel, UIAlignAnchor.TopLeft);
-            button2.relativePosition += new UnityEngine.Vector3(button1.width + 10, 0);
-            group.AddSpace(10);
-
-            dropdown = group.AddDropdown("Report type: ", new string[] { "text" /*, "html", "text and html" */ }, 0, (int _) => { }) as UIDropDown; // Todo 0.8 Remove /* */
-            dropdown.width = 180f;
-            container = dropdown.parent;
-            panel = container.AddUIComponent<UIPanel>();
-            panel.width = container.width;
-            panel.height = dropdown.height;
-            button1 = group.AddButton("Open report(s)", () => dummy++) as UIButton;
-            button1.isVisible = settingsVisible;    // Todo 0.8 Remove this.
-            button2 = group.AddButton("Generate report(s)", () => dummy++) as UIButton;
-            button2.isVisible = settingsVisible;    // Todo 0.8 Remove this.
-            button1.AlignTo(panel, UIAlignAnchor.TopLeft);
-            button1.relativePosition += new UnityEngine.Vector3(dropdown.width + 30, -button1.height);
-            button2.AlignTo(panel, UIAlignAnchor.TopLeft);
-            button2.relativePosition += new UnityEngine.Vector3(dropdown.width + 30 + button1.width + 10, -button1.height);
-
-            group = helper.AddGroup("Catalog options:");
-            panel = (group as UIHelper).self as UIPanel;
-
-            label = panel.AddUIComponent<UILabel>();
-            label.processMarkup = true;
-            label.text = $"Catalog version: { CatalogData.Catalog.SettingsUIText }";
-            label.textScale = 1.1f;
-            group.AddSpace(10);
-            
-            dropdown = group.AddDropdown("Download: ",  // Todo 0.8 Remove /* */
-                new string[] { "Every game start", /* "Once per day", "Once a week", "Never (on-demand only) - not recommended!" */ }, 0, (int _) => { }) as UIDropDown;
-            dropdown.width = 290f;
-            container = dropdown.parent;
-            panel = container.AddUIComponent<UIPanel>();
-            panel.width = container.width;
-            panel.height = dropdown.height;
-            button1 = group.AddButton("Download now", () => dummy++) as UIButton;
-            button1.isVisible = settingsVisible;    // Todo 0.8 Remove this.
-            button1.AlignTo(panel, UIAlignAnchor.TopLeft);
-            button1.relativePosition += new UnityEngine.Vector3(dropdown.width + 30, -button1.height);
-
-            group = helper.AddGroup("Advanced options:");
-            panel = (group as UIHelper).self as UIPanel;
-
-            label = panel.AddUIComponent<UILabel>();
-            label.processMarkup = true;
-            label.text = $"Mod version: <color { ModSettings.SettingsUIColor }>{ ModSettings.FullVersion }</color>";
-            label.textScale = 1.1f;
-
-            // Todo 0.8 Activate checkboxes and button
-            // group.AddCheckbox("Show source URL in report", false, (bool _) => { });
-            // group.AddCheckbox("Show download date/time of mods in report", false, (bool _) => { });
-            // group.AddCheckbox("Debug logging", false, (bool _) => { });
-            group.AddSpace(10);
-            
-            // group.AddButton("Ignore selected incompatibilities", () => dummy++);
-
-            helper.AddButton("Reset all settings", () => dummy++);
-
-            /* OLD FIELDS, NO LONGER USED:
-
-                UITextField textField = group.AddTextfield("Report path:", Toolkit.Privacy(ModSettings.ReportPath), (string _) => { }) as UITextField;
-                textField.width = 650f;
-                textField.textScale = 0.8f;
-                textField.readOnly = true;
-
-                UIHelper subGroup = group.AddGroup(" ") as UIHelper;
-                var panel = subGroup.self as UIPanel;
-                panel.autoLayoutDirection = LayoutDirection.Horizontal;
-                panel.autoLayoutPadding = new UnityEngine.RectOffset(5, 5, 0, 0);
-                subGroup.AddButton("Open text report", () => dummy++);
-                subGroup.AddButton("Open HTML report", () => dummy++);
-                subGroup.AddButton("Generate new report", () => dummy++);
-            */
+            SettingsUI.Create(helper);
         }
     }
 }

--- a/CompatibilityReport/CompatibilityReport.csproj
+++ b/CompatibilityReport/CompatibilityReport.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -67,8 +69,24 @@
     <Compile Include="CatalogData\Compatibility.cs" />
     <Compile Include="CatalogData\Group.cs" />
     <Compile Include="CatalogData\Mod.cs" />
+    <Compile Include="Reporter\HtmlReport.cs" />
+    <Compile Include="Reporter\HtmlTemplates\HtmlExtensions.cs" />
+    <Compile Include="Reporter\HtmlTemplates\HtmlReportTemplateCode.cs" />
+    <Compile Include="Reporter\HtmlTemplates\HtmlReportTemplate.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>HtmlReportTemplate.tt</DependentUpon>
+    </Compile>
     <Compile Include="Reporter\Report.cs" />
     <Compile Include="Reporter\TextReport.cs" />
+    <Compile Include="Settings\ConfigData\AdvancedConfig.cs" />
+    <Compile Include="Settings\ConfigData\GeneralConfig.cs" />
+    <Compile Include="Settings\ConfigData\UpdaterConfig.cs" />
+    <Compile Include="Settings\GlobalConfig.cs" />
+    <Compile Include="Settings\SettingsManager.cs" />
+    <Compile Include="UI\ProgressMonitor.cs" />
+    <Compile Include="UI\ProgressMonitorUI.cs" />
+    <Compile Include="UI\SettingsUI.cs" />
     <Compile Include="Updater\ChangeNotes.cs" />
     <Compile Include="Updater\OneTimeAction.cs" />
     <Compile Include="Updater\WebCrawler.cs" />
@@ -76,6 +94,7 @@
     <Compile Include="Updater\FirstCatalog.cs" />
     <Compile Include="Updater\DataDumper.cs" />
     <Compile Include="Updater\FileImporter.cs" />
+    <Compile Include="Util\GameObjectObserver.cs" />
     <Compile Include="Util\ModSettings.cs" />
     <Compile Include="Util\Logger.cs" />
     <Compile Include="CompatibilityReport.cs" />
@@ -85,6 +104,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Updater\Updater Guide.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Reporter\HtmlTemplates\HtmlReportTemplate.tt">
+      <Generator>TextTemplatingFilePreprocessor</Generator>
+      <LastGenOutput>HtmlReportTemplate.cs</LastGenOutput>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/CompatibilityReport/CompatibilityReport.csproj
+++ b/CompatibilityReport/CompatibilityReport.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Reporter\Report.cs" />
     <Compile Include="Reporter\TextReport.cs" />
     <Compile Include="Updater\ChangeNotes.cs" />
+    <Compile Include="Updater\OneTimeAction.cs" />
     <Compile Include="Updater\WebCrawler.cs" />
     <Compile Include="Updater\CatalogUpdater.cs" />
     <Compile Include="Updater\FirstCatalog.cs" />

--- a/CompatibilityReport/CompatibilityReport.csproj
+++ b/CompatibilityReport/CompatibilityReport.csproj
@@ -113,9 +113,15 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>REM mkdir "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)"
-REM del "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)\$(TargetFileName)"
-REM xcopy /y "$(TargetPath)" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)"
-xcopy /y "$(TargetPath)" "C:\Games\Steam Games\steamapps\workshop\content\255710\2633433869\"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+      <!-- if Release target: copy to workshop directory -->
+      xcopy /y "$(TargetPath)" "C:\Games\Steam Games\steamapps\workshop\content\255710\2633433869\"
+    </PostBuildEvent>
+    <PostBuildEvent Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+      <!-- if Debug target: copy to workshop directory -->
+      mkdir "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)"
+      del "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)\$(TargetFileName)"
+      xcopy /y "$(TargetPath)" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)"
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/CompatibilityReport/Reporter/HtmlReport.cs
+++ b/CompatibilityReport/Reporter/HtmlReport.cs
@@ -1,0 +1,58 @@
+﻿using System.IO;
+using CompatibilityReport.CatalogData;
+using CompatibilityReport.Reporter.HtmlTemplates;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Settings.ConfigData;
+using CompatibilityReport.Util;
+
+namespace CompatibilityReport.Reporter
+{
+    public class HtmlReport
+    {
+        private readonly Catalog catalog;
+        public HtmlReport(Catalog currentCatalog)
+        {
+            catalog = currentCatalog;
+        }
+        public void Create()
+        {
+            HtmlReportTemplate template = new HtmlReportTemplate(catalog);
+            SaveReport(template.TransformText());
+        }
+        
+        private void SaveReport(string reportText)
+        {
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            string htmlReportFullPath = Path.Combine(config.ReportPath, ModSettings.ReportHtmlFileName);
+            Toolkit.DeleteFile($"{ htmlReportFullPath }.old");
+
+            if (Toolkit.SaveToFile(reportText, htmlReportFullPath, createBackup: GlobalConfig.Instance.AdvancedConfig.DebugMode))
+            {
+                Logger.Log($"Html Report ready at \"{ Toolkit.Privacy(htmlReportFullPath) }\".");
+                return;
+            }
+
+            Logger.Log($"Html Report could not be saved to \"{ Toolkit.Privacy(htmlReportFullPath) }\". Trying an alternative location.", Logger.Warning);
+
+            string altHtmlReportFullPath = Path.Combine(ModSettings.DefaultReportPath, ModSettings.ReportHtmlFileName);
+            Toolkit.DeleteFile($"{ altHtmlReportFullPath }.old");
+            if ((config.ReportPath != ModSettings.DefaultReportPath) && Toolkit.SaveToFile(reportText.ToString(), altHtmlReportFullPath))
+            {
+                Logger.Log($"Html Report could not be saved to the location set in the options. It is instead saved as \"{ Toolkit.Privacy(altHtmlReportFullPath) }\".", 
+                    Logger.Warning);
+                return;
+            }
+
+            altHtmlReportFullPath = Path.Combine(ModSettings.AlternativeReportPath, ModSettings.ReportHtmlFileName);
+            Toolkit.DeleteFile($"{ altHtmlReportFullPath }.old");
+            if (Toolkit.SaveToFile(reportText.ToString(), altHtmlReportFullPath))
+            {
+                Logger.Log($"Html Report could not be saved to the location set in the options. It is instead saved as \"{ Toolkit.Privacy(altHtmlReportFullPath) }\".", 
+                    Logger.Warning);
+                return;
+            }
+
+            Logger.Log($"Html Report could not be saved. No report was created.", Logger.Error);
+        }
+    }
+}

--- a/CompatibilityReport/Reporter/HtmlTemplates/HtmlExtensions.cs
+++ b/CompatibilityReport/Reporter/HtmlTemplates/HtmlExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using CompatibilityReport.CatalogData;
+using CompatibilityReport.Util;
+
+namespace CompatibilityReport.Reporter.HtmlTemplates
+{
+    /// <summary>
+    /// Set of extensions to wrap text in html tags
+    /// </summary>
+    public static class HtmlExtensions
+    {
+
+        public static string Attribute(this string name, string content)
+        {
+            return string.IsNullOrEmpty(content) ? String.Empty : $"{name}=\"{content}\"";
+        }
+
+        public static string Classes(this string classes)
+        {
+            return string.IsNullOrEmpty(classes) ? string.Empty : "class".Attribute(classes);
+        }
+        
+        public static string Tag(this string name, string content, string classes = null)
+        {
+            return string.IsNullOrEmpty(content) ? string.Empty : $"<{name} {classes.Classes()}>{content}</{name}>";
+        }
+        
+        public static string A(this string url, string text= null, string classes = null)
+        {
+            return string.IsNullOrEmpty(url) ? string.Empty : $"<a {"href".Attribute(url)} {classes.Classes()}>{text ?? url}</a>";
+        }
+        
+        public static string TagConditional(this string name, bool shouldRender, string content, string classes = null)
+        {
+            return string.IsNullOrEmpty(content) || !shouldRender ? string.Empty : $"<{name} {classes.Classes()}>{content}</{name}>";
+        }
+
+        internal static string NestedLi(this List<Message> items)
+        {
+            if (items != null)
+            {
+                string list = "";
+                foreach (Message listItem in items)
+                {
+                    list += "li".Tag( listItem.message + "ul".Tag("li".Tag(listItem.details, "details")), "message");
+                }
+                return list;
+            }
+            return string.Empty;
+        }
+        
+        public static string AsLink(this string link, string text = null, string classes = null)
+        {
+            return A(link, text, classes);
+        }
+        
+        public static string NameWithIDAsLink(this Mod mod, bool fakeId = true, bool idFirst = false)
+        {
+            return idFirst 
+                ? $"{ mod.IdString(fakeId)} {AsLink(Toolkit.GetWorkshopUrl(mod.SteamID), mod.Name) }"
+                : $"{ A(Toolkit.GetWorkshopUrl(mod.SteamID), mod.Name)} {mod.IdString(fakeId) }";
+        }
+
+        public static string NameAuthorWithIDAsLink(string name, string author, string url, string idString)
+        {
+            return $"{ (string.IsNullOrEmpty(url) ? "span".Tag(name, "modName") : url.AsLink(name, "modName")) } by " +
+                $"{ "span".Tag(author, "author") }&nbsp;{ "span".Tag(idString, "steamId") }";
+        }
+    }
+}

--- a/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplate.tt
+++ b/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplate.tt
@@ -259,7 +259,7 @@
 #>
                     <div class="report-content border-b_<#= style #>">
                         <p>
-                            <#= "span".TagConditional(modInfo.isDisabled, "DISABLED &nbsp;", "disabled minor") #>
+                            <#= "span".TagConditional(modInfo.isDisabled, "DISABLED", "disabled minor") #>
                             <#= HtmlExtensions.NameAuthorWithIDAsLink(modInfo.modName, modInfo.authorName, modInfo.steamUrl, modInfo.idString) #>
                         </p>
                         <#= ListItem(modInfo.instability, "instability mt-1") #>

--- a/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplate.tt
+++ b/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplate.tt
@@ -1,0 +1,331 @@
+<#@ template language="C#v3.5" linePragmas="false" visibility="internal" #>
+<#@ import namespace="Util" #>
+<#@ import namespace="System" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension="html" encoding="utf-8" #>
+<#@ import namespace="System.Linq" #>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><#= ModSettings.ModName #></title>
+</head>
+<style>
+    /* 
+        unsubscribe-color: #dd2323
+        major-color: #e69138
+        minor-color: #ffd966
+        remark-color: #93c47d
+        nothing-color: #5a9b3d
+        processed-color: #4cb2e9
+     */
+    * {font-family:sans-serif;}
+    body {background-color:#f9f6ea; margin: 12px}
+    header {padding: 0 10px;}
+    article header {padding: 0; }
+    footer {margin: 20px 0px 40px 10px}
+    section {padding: 0 10px;}
+
+    h1 {margin-top: 10px; margin-bottom: 0; padding:24px 18px; background-color:#e8e5d4;}
+    h2 {margin-top:0px; border-bottom:1px solid black;}
+    h3 {margin: 20px 0 0 0px; }
+    h4 {margin: 20px 0 0 18px; }
+    a:link {color: black; text-decoration: underline;}
+    a:visited {color: black; text-decoration: underline;}
+    a:hover {color: #0000e0; text-decoration: underline;}
+
+    nav { position: sticky; top: 0; }
+    nav ul { width: 100%; display: flex; align-items: center; min-height: 40px; padding: 0 10px; background-color: #f9f6ea; }
+    nav ul li { display: flex; list-style: none; font-weight: bold; font-size: 16px; cursor: pointer;}
+    nav ul li:hover { background-color: #f9f6ea; }
+    nav ul li a { padding: 12px 15px; text-decoration: none!important; color: black; }
+    nav ul li a:link { text-decoration: none!important; color: black; }
+    nav ul li a:visited { text-decoration: none!important; color: black; }
+    nav ul li a:hover { text-decoration: none!important; color: black; }
+
+    article[id] { margin-top: -40px; padding-top: 60px; }
+    
+    table { font-family: arial, sans-serif; border-collapse: collapse; width: 100%; }
+    td, th { border: 1px solid #dddddd; text-align: left; padding: 8px; }
+    tr:nth-child(even) { background-color: #e7e7e7; }
+
+    .text-smaller {font-size: 13px; }
+    .text-small {font-size: 15px; }
+    .show {display: inherit;}
+    .hide {display: none; }
+    .warn { color: #ff9200; }
+    .error { color: red; }
+    .font-bold { font-weight: 600; }
+
+    .mt-1 { margin-top: 1rem; }
+    .center {text-align: center; }
+    .report-section__titleBar { margin-left: 0; padding: 10px;}
+    .report-section__title { }
+    .report-section__content {margin-left: 0; padding: 5px}
+    .report-content:last-child { border-bottom: unset !important; }
+    li.message a {min-width: 260px; display: inline-block;}   
+
+    .author,.modName {font-weight: bold;}
+
+    .disabled {padding: 5px; font-weight: bold;}
+    .unsubscribe {background-color: #dd2323; color: #f9f6ea}
+    .major {background-color: #e69138;}
+    .minor {background-color: #ffd966;}
+    .remark {background-color: #93c47d;}
+    .nothing {background-color: #5a9b3d; color: #f9f6ea}
+    .processed {background-color: #4cb2e9;}
+    
+    .line_unsubscribe {margin-top:-6px; margin-left:0px; border-left: solid 10px #dd2323; border-bottom: solid 10px #dd2323;}
+    .line_major {margin-top:-6px; margin-left:0px; border-left: solid 10px #e69138; border-bottom: solid 10px #e69138;}
+    .line_minor {margin-top:-6px; margin-left:0px; border-left: solid 10px #ffd966; border-bottom: solid 10px #ffd966;}
+    .line_remark {margin-top:-6px; margin-left:0px; border-left: solid 10px #93c47d; border-bottom: solid 10px #93c47d;}
+    .line_nothing {margin-top:-6px; margin-left:0px; border-left: solid 10px #5a9b3d; border-bottom: solid 10px #5a9b3d;}
+    .line_processed {margin-top:-6px; margin-left:0px; border-left: solid 10px #4cb2e9; border-bottom: solid 10px #4cb2e9;}
+    .border-b_unsubscribe {border-bottom: solid 2px #dd2323;}
+    .border-b_major {border-bottom: solid 2px #e69138;}
+    .border-b_minor {border-bottom: solid 2px #ffd966;}
+    .border-b_remark {border-bottom: solid 2px #93c47d;}
+    .border-b_nothing {border-bottom: solid 2px #5a9b3d;}
+    .border-b_processed {border-bottom: solid 2px #4cb2e9;}
+</style>
+
+<body>
+    <header>
+        <h1> <#= ModSettings.ModName #>, created on <#= $"{reportCreationTime:d MMMM yyyy}" #>, <#= $"{reportCreationTime:t}" #></h1>
+    </header>
+
+    <nav>
+        <ul>
+          <# string LI_Link(bool shouldRender, string text, string anchor) => shouldRender ? "<li class=\"" + anchor + "\"><a href=\"#" + anchor + $"\">{text}</a></li>" : ""; #>
+
+          <#= LI_Link(unsubscribe.Count > 0, $"Unsubscribe ({unsubscribe.Count})", "unsubscribe") #>
+          <#= LI_Link(majorIssues.Count > 0, $"Major Issues ({majorIssues.Count})", "major") #>
+          <#= LI_Link(minorIssues.Count > 0, $"Minor Issues ({minorIssues.Count})", "minor") #>
+          <#= LI_Link(remarks.Count > 0, $"Remarks ({remarks.Count})", "remark") #>
+          <#= LI_Link(nothingToReport.Count > 0, $"Nothing to report ({nothingToReport.Count})", "nothing") #>
+          <#= LI_Link(true, $"Mod List ({AllModList().Length})", "processed") #>
+        </ul>
+    </nav>
+
+    <section>
+        <div>
+            <span class="text-smaller">Version <strong><#= ModSettings.FullVersion #></strong> with catalog <strong><#= catalog.VersionString() #></strong>. 
+            Your game has <strong><#= catalog.SubscriptionCount() #></strong> mods.</span>
+            <span class="text-smaller">The mod catalog contains <strong><#= catalog.ReviewedModCount #></strong> reviewed mods and was created on <#= $"{catalog.Updated:d MMMM yyyy}" #>.</span>
+            <br>
+            <span class="text-small mt-1">Mods updated after this date might have an outdated review below.</span>
+            <hr>
+        </div>
+    
+        <div>
+            <#= Toolkit.WordWrap(ModSettings.ReportTextForThisModVersion) #>
+        </div>
+    
+        <div>
+            <#= Toolkit.WordWrap(catalog.Note) #>
+        </div>
+    </section>
+
+    <section>
+<#  // Different Catalog version
+    if (IsDifferentVersion) {#>
+    <div>
+        <h3>WARNING:</h3>
+        <span>The catalog is made for game version <#= CatalogGameVersion #>.</span>
+        <span>Your game is <#= IsOlder ? "older" : "newer" #> (<#= CurrentGameVersion #>>).</span>
+        <span>Results might not be accurate.</span>
+    </div><#
+    }
+#>
+    
+<#  // Local subscriptions
+    if (catalog.LocalSubscriptionCount != 0) {#>
+        <h3>NOTE</h3>
+        <div class="text-small">
+          <span>You have <strong><#= catalog.LocalSubscriptionCount #></strong> local mod<#= catalog.LocalSubscriptionCount == 1 ? "" : "s" #> local mods, which we can't review. The report does not check for incompatibilities with these. Results might not be completely accurate.</span>
+          </br>
+          <span>Use mods as Workshop subscription whenever possible. Mods copied to the local mods folder don't always work and often cannot be detected correctly by other mods.</span> 
+        </div><#
+    }
+#>
+
+<#  // Fake subscriptions
+    if (catalog.FakeSubscriptionCount != 0) { #>
+        <h3>NOTE</h3>
+        <div>
+           <span>The report includes <strong><#= catalog.LocalSubscriptionCount #></strong> fake subscription<#= catalog.FakeSubscriptionCount == 1 ? "" : "s" #>.</span> 
+        </div><#
+    }
+#>
+
+<#  // Non reviewed subscriptions
+    if (NonReviewedSubscriptions != 0) { #>
+        <h3>NOTE</h3>
+        <div>
+           <span><strong><#= NonReviewedSubscriptions #></strong> of your mods have not been reviewed yet. Some incompatibilities or warnings might be missing in the report due to this.</span> 
+        </div><#
+    }
+#>
+
+    <h3>General information</h3>
+    <ul style="padding-left: 30px">
+        <li> Always <strong>EXIT TO DESKTOP</strong> and restart the game. Never exit to main menu!</li> 
+        <li> <strong>NEVER</strong> (un)subscribe to anything while the game is running! This resets some mods.</li> 
+        <li> When playing with mods, save to a new savegame often and make frequent <strong>BACKUPS</strong>.</li> 
+        <li> Always <strong>READ</strong> the mod description on the Steam Workshop before subscribing.</li>
+        <li> Having issues with a mod? Make a comment on its Workshop page so the author knows.</li>
+        <li> Abandoned mods can still work fine. They're just unlikely to get updates.</li>
+        <li> Mod compatible, but not working? Try unsubscribe and resubscribe (while not in game).</li>
+        <li> Found a mistake? Please fill out this <a href="https://forms.gle/PvezwfpgS1V1DHqA9>">form</a>.</li>
+    </ul>
+
+<#  // Is outdated
+    if (ShowOutdatedWarning) { #>    
+    <h3 class="warn <#= ShowOutdatedWarning ? "show" : "hide" #>">
+        <strong>WARNING:</strong> The latest review catalog could not be downloaded. Results might be outdated.
+    </h3><#
+    }
+#>
+    </section>
+
+<# // Reusable template
+    
+    string NestedList(MessageList nestedList, string classes = null)
+    {
+        if (nestedList?.messages == null) return string.Empty;
+
+        return !string.IsNullOrEmpty(nestedList.title) 
+            ? "ul".Tag( "li".Tag(nestedList.title, "title") + "ul".Tag(nestedList.messages.NestedLi()), classes)
+            : "ul".Tag(nestedList.messages.NestedLi(), classes);
+    }
+
+    string ListItem(Message item, string classes = null) {
+        return item == null
+            ? string.Empty
+            : "ul".Tag(
+                "li".Tag(item.message + BulletList(item.details, "details"))
+                , classes);
+    }
+
+    string BulletList(string text, string classes = null) {
+        return string.IsNullOrEmpty(text)
+            ? string.Empty
+            : "ul".Tag(
+                string.Join("\n", text
+                    .Split('\n')
+                    .Select(part => "li".Tag(part))
+                    .ToArray())
+                , classes);
+    }
+
+    void RenderSection(int number, string title, string css_style, Func<string> content)
+    {
+        if (number == 0) return;
+#>
+          <article id="<#= css_style #>">
+             <header>                
+               <h3 class="report-section__titleBar <#= css_style #>">
+                   <span><#= number #></span>&nbsp;<span class="report-section__title"><#= title #></span>
+               </h3>
+             </header>
+             <section class="line_<#= css_style #>">
+                <div class="report-section__content">
+                  <#
+        if (content != null)
+            content();
+#>
+                </div>
+             </section>
+          </article>
+<#  }
+    
+    string RenderContent(List<ModInfo> list, string style)
+        {
+            foreach (ModInfo modInfo in list)
+            {
+                if (modInfo.isLocal)
+                {#>
+                    <div class="report-content border-b_<#= style #>">
+                        <p class="font-bold"><#= modInfo.modName #></p>
+                        <ul>
+                            <li><#= cannotReviewMessage #></li>                        
+                        </ul>
+                        <p class="<#= modInfo.isCameraScript? "": "hide" #>"><#= isCameraScriptMessage #></p>
+                    </div><#                    
+                }
+                else
+                {
+#>
+                    <div class="report-content border-b_<#= style #>">
+                        <p>
+                            <#= "span".TagConditional(modInfo.isDisabled, "DISABLED &nbsp;", "disabled minor") #>
+                            <#= HtmlExtensions.NameAuthorWithIDAsLink(modInfo.modName, modInfo.authorName, modInfo.steamUrl, modInfo.idString) #>
+                        </p>
+                        <#= ListItem(modInfo.instability, "instability mt-1") #>
+                        <#= NestedList(modInfo.requiredDlc, "requiredDlc mt-1") #>
+                        <#= ListItem(modInfo.unneededDependencyMod, "unnededDependency mt-1") #>
+                        <#= ListItem(modInfo.disabled, "disabledMod mt-1") #>
+                        <#= NestedList(modInfo.successors, "successors mt-1") #>
+                        <#= ListItem(modInfo.stability, "stability mt-1") #>
+                        <#= NestedList(modInfo.compatibilities, "compatibilities mt-1") #>
+                        <#= NestedList(modInfo.requiredMods, "requiredMods mt-1") #>
+                        <#= NestedList(modInfo.statuses, "statuses mt-1") #>
+                        <#= BulletList(modInfo.note, "note mt-1") #>
+                        <#= NestedList(modInfo.alternatives, "alternatives mt-1") #>
+                        <#= NestedList(modInfo.recommendations, "recommendations") #>
+                        <#= "ul".TagConditional(modInfo.anyIssues, "li".Tag(noKnownIssuesMessage), "noKnownIssues mt-1") #>
+                        <#= "ul".TagConditional(modInfo.isCameraScript, "li".Tag(isCameraScriptMessage), "isCameraScript mt-1") #>
+                    </div><#
+                }
+            }
+            return "";
+        } 
+// End Reusable templates
+#>
+
+    <section>   
+        <# RenderSection(unsubscribe.Count, $"{(unsubscribe.Count == 1 ? "MOD" : "MODS") } COULD OR SHOULD BE UNSUBSCRIBED:", "unsubscribe", () => RenderContent(unsubscribe, "unsubscribe")); #>
+        <# RenderSection(majorIssues.Count, $"{(majorIssues.Count == 1 ? "MOD HAS" : "MODS HAVE") } MAJOR ISSUES:", "major", () => RenderContent(majorIssues, "major")); #>
+        <# RenderSection(minorIssues.Count, $"{(minorIssues.Count == 1 ? "MOD HAS" : "MODS HAVE") } MINOR ISSUES:", "minor", () => RenderContent(minorIssues, "minor")); #>
+        <# RenderSection(remarks.Count, $"{(remarks.Count == 1 ? "MOD" : "MODS") } WITH REMARKS:", "remark", () => RenderContent(remarks, "remark")); #>
+        <# RenderSection(nothingToReport.Count, $"{(nothingToReport.Count == 1 ? "MOD" : "MODS")} WITH NOTHING TO REPORT:", "nothing", () => RenderContent(nothingToReport, "nothing")); #>
+    </section>
+
+    <section>
+        <article id="processed">    
+            <h3 class="report-section__titleBar processed">Processed mods</h3>
+        
+            <div class="line_processed" style="padding: 10px">
+                <table style="margin-top: 10px">
+                    <tr>
+                        <th>Mod Name</th>
+                        <th>Disabled</th>
+                        <th>Type</th>
+                        <th>Url</th>
+                    </tr>
+<#
+                foreach (InstalledModInfo modInfo in AllModList())
+                {
+#>
+                    <tr>
+                       <td><#= modInfo.subscriptionName #></td>
+                       <td class="font-bold center"><#= modInfo.disabled #></td>
+                       <td><#= modInfo.type #></td>
+                       <td><#= OptionalUrlLink(modInfo.url, modInfo.isSteam) #></td>
+                    </tr>
+<#
+                }
+#>
+                </table>
+            </div>
+        </article>
+    </section>
+
+    <footer>
+        <hr>
+        <span> <#= catalog.ReportFooterText #> </span>
+    </footer>
+
+</body>
+</html>

--- a/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplateCode.cs
+++ b/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplateCode.cs
@@ -1,0 +1,844 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ColossalFramework.PlatformServices;
+using CompatibilityReport.CatalogData;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Util;
+
+namespace CompatibilityReport.Reporter.HtmlTemplates
+{
+    internal partial class HtmlReportTemplate
+    {
+        private const string isCameraScriptMessage = "This is a cinematic camera script, which technically is a mod and thus listed here.";
+        private const string noKnownIssuesMessage = "No known issues or incompatibilities with your other mods.";
+        private const string cannotReviewMessage = "Can't review local mods.";
+        private readonly List<ModInfo> unsubscribe, majorIssues, minorIssues, remarks, nothingToReport;
+        private readonly DateTime reportCreationTime;
+        private readonly Catalog catalog;
+
+        private bool IsDifferentVersion => Toolkit.CurrentGameVersion() != catalog.GameVersion();
+        private bool IsOlder => Toolkit.CurrentGameVersion() < catalog.GameVersion();
+        private bool ShowOutdatedWarning => Catalog.DownloadStarted && !Catalog.DownloadSuccessful;
+        private int NonReviewedSubscriptions => catalog.SubscriptionCount() - catalog.ReviewedSubscriptionCount - catalog.LocalSubscriptionCount;
+        private string CatalogGameVersion => Toolkit.ConvertGameVersionToString(catalog.GameVersion());
+        private string CurrentGameVersion => Toolkit.ConvertGameVersionToString(Toolkit.CurrentGameVersion());
+
+        public HtmlReportTemplate(Catalog catalog)
+        {
+            this.catalog = catalog;
+            reportCreationTime = DateTime.Now;
+            unsubscribe = new List<ModInfo>();
+            majorIssues = new List<ModInfo>();
+            minorIssues = new List<ModInfo>();
+            remarks = new List<ModInfo>();
+            nothingToReport = new List<ModInfo>();
+            GenerateModInfo();
+        }
+
+        private string OptionalUrlLink(string url, bool isLink) => isLink ? HtmlExtensions.A(url) : url;
+        
+        // todo 0.8 or 0.9 identify if necessary to be read from catalog 
+        private string CatalogHeaderText => catalog.ReportHeaderText;
+        
+        private InstalledModInfo[] AllModList()
+        {
+            List<InstalledModInfo> items = new List<InstalledModInfo>();
+            foreach (string subscriptionName in catalog.GetSubscriptionNames())
+            {
+                foreach (ulong steamID in catalog.GetSubscriptionIDsByName(subscriptionName))
+                {
+                    Mod catalogMod = catalog.GetMod(steamID);
+                    string disabled = (catalogMod.IsDisabled ? "Yes" : "");
+                    bool isSteam = steamID > ModSettings.HighestFakeID;
+                    string type = (isSteam ? "Steam" : steamID < ModSettings.LowestLocalModID ? "Built-in" : "Local");
+                    string url = steamID > ModSettings.HighestFakeID ? Toolkit.GetWorkshopUrl(steamID) : $"{Toolkit.Privacy(catalogMod.ModPath)}";
+
+                    items.Add(new InstalledModInfo(subscriptionName, disabled, type, isSteam, url));
+                }
+            }
+            return items.ToArray();
+        }
+
+        private void GenerateModInfo()
+        {
+            if (GlobalConfig.Instance.GeneralConfig.ReportSortByName)
+            {
+                // Report mods sorted by name.
+                List<string> AllSubscriptionNames = catalog.GetSubscriptionNames();
+
+                foreach (string name in AllSubscriptionNames)
+                {
+                    // Get the Steam ID(s) for this mod name. There could be multiple IDs for mods with the same name.
+                    foreach (ulong steamID in catalog.GetSubscriptionIDsByName(name))
+                    {
+                        CreateModText(steamID);
+                    }
+                }
+            }
+            else
+            {
+                // Report mods sorted by Steam ID.
+                foreach (ulong steamID in catalog.GetSubscriptionIDs())
+                {
+                    CreateModText(steamID);
+                }
+            }
+        }
+
+        /// <summary>Creates the report object for a single mod.</summary>
+        /// <remarks>The object is added to the relevant collection.</remarks>
+        private void CreateModText(ulong steamID)
+        {
+            Mod subscribedMod = catalog.GetMod(steamID);
+            Author subscriptionAuthor = catalog.GetAuthor(subscribedMod.AuthorID, subscribedMod.AuthorUrl);
+            string authorName = subscriptionAuthor == null ? "" : subscriptionAuthor.Name;
+
+            ModInfo modInfo = new ModInfo();
+            modInfo.authorName = authorName;
+            modInfo.modName = subscribedMod.Name;
+            modInfo.idString = subscribedMod.IdString(true);
+            modInfo.isDisabled = subscribedMod.IsDisabled;
+            modInfo.isLocal = subscribedMod.SteamID >= ModSettings.LowestLocalModID && subscribedMod.SteamID <= ModSettings.HighestLocalModID;
+            modInfo.isCameraScript = subscribedMod.IsCameraScript;
+            if (!modInfo.isLocal)
+            {
+                modInfo.instability = Instability(subscribedMod);
+                modInfo.requiredDlc = RequiredDlc(subscribedMod);
+                modInfo.unneededDependencyMod = UnneededDependencyMod2(subscribedMod);
+                modInfo.disabled = Disabled(subscribedMod);
+                modInfo.successors = Successors(subscribedMod);
+                modInfo.stability = Stability(subscribedMod);
+                modInfo.compatibilities = Compatibilities(subscribedMod);
+                modInfo.requiredMods = RequiredMods(subscribedMod);
+                modInfo.statuses = Statuses(subscribedMod, authorRetired: (subscriptionAuthor != null && subscriptionAuthor.Retired));
+                modInfo.note = ModNote(subscribedMod);
+                modInfo.alternatives = Alternatives(subscribedMod);
+                modInfo.reportSeverity = subscribedMod.ReportSeverity;
+                modInfo.recommendations = subscribedMod.ReportSeverity <= Enums.ReportSeverity.MajorIssues ? Recommendations2(subscribedMod) : null;
+                modInfo.anyIssues = subscribedMod.ReportSeverity == Enums.ReportSeverity.NothingToReport && subscribedMod.Stability > Enums.Stability.NotReviewed;
+                modInfo.isCameraScript = subscribedMod.IsCameraScript;
+                modInfo.steamUrl = subscribedMod.SteamID > ModSettings.HighestFakeID ? Toolkit.GetWorkshopUrl(steamID) : null;
+            }
+         
+            switch (subscribedMod.ReportSeverity)
+            {
+                case Enums.ReportSeverity.Unsubscribe:
+                    unsubscribe.Add(modInfo);
+                    break;
+                case Enums.ReportSeverity.MajorIssues:
+                    majorIssues.Add(modInfo);
+                    break;
+                case Enums.ReportSeverity.MinorIssues:
+                    minorIssues.Add(modInfo);
+                    break;
+                case Enums.ReportSeverity.Remarks:
+                    remarks.Add(modInfo);
+                    break;
+                default:
+                    nothingToReport.Add(modInfo);
+                    break;
+            }
+        }
+
+        /// <summary>Creates report message for stability issues of a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <remarks>Only reports major issues and worse.</remarks>
+        /// <returns>Text wrapped in Message object.</returns>
+        private Message Instability(Mod subscribedMod)
+        {
+            switch (subscribedMod.Stability)
+            {
+                case Enums.Stability.IncompatibleAccordingToWorkshop:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                    return new Message(){message = "UNSUBSCRIBE! This mod is totally incompatible with the current game version.", details = subscribedMod.StabilityNote};
+
+                case Enums.Stability.RequiresIncompatibleMod:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                    return new Message(){message = "UNSUBSCRIBE! This requires a mod that is totally incompatible with the current game version.", details = subscribedMod.StabilityNote};
+
+                case Enums.Stability.GameBreaking:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                    return new Message(){message = "UNSUBSCRIBE! This mod breaks the game.", details = subscribedMod.StabilityNote};
+
+                case Enums.Stability.Broken:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                    return new Message(){message = "Unsubscribe! This mod is broken.", details = subscribedMod.StabilityNote};
+
+                case Enums.Stability.MajorIssues:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MajorIssues);
+                    return new Message(){message = $"Unsubscribe would be wise. This has major issues{(string.IsNullOrEmpty(subscribedMod.StabilityNote) ? ". Check its Workshop page for details." : ":")}", details = subscribedMod.StabilityNote};
+
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>Creates report message for the stability of a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <remarks>Only reports minor issues and better.</remarks>
+        /// <returns>Text wrapped in Message object.</returns>
+        private Message Stability(Mod subscribedMod)
+        {
+            switch (subscribedMod.Stability)
+            {
+                case Enums.Stability.MinorIssues:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MinorIssues);
+                    return new Message()
+                    {
+                        message = $"This has minor issues{(string.IsNullOrEmpty(subscribedMod.StabilityNote) ? ". Check its Workshop page for details." : ":")}",
+                        details = subscribedMod.StabilityNote,
+                    };
+
+                case Enums.Stability.UsersReportIssues:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MinorIssues);
+                    return new Message()
+                    {
+                        message = $"Users are reporting issues{(string.IsNullOrEmpty(subscribedMod.StabilityNote) ? ". Check its Workshop page for details." : ": ")}",
+                        details = subscribedMod.StabilityNote,
+                    };
+                case Enums.Stability.NotEnoughInformation:
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+                    string updatedText = subscribedMod.GameVersion() < Toolkit.CurrentMajorGameVersion() 
+                        ? "." 
+                        : subscribedMod.GameVersion() == Toolkit.CurrentGameVersion() 
+                            ? ", but it was updated for the current game version."
+                            : $", but it was updated for game version {subscribedMod.GameVersion().ToString(2)}.";
+                    return new Message()
+                    {
+                        message = $"There is not enough information about this mod to know if it works well{updatedText}",
+                        details = subscribedMod.StabilityNote,
+                    };
+                case Enums.Stability.Stable:
+                    subscribedMod.IncreaseReportSeverity(string.IsNullOrEmpty(subscribedMod.StabilityNote) ? Enums.ReportSeverity.NothingToReport : Enums.ReportSeverity.Remarks);
+                    return new Message()
+                    {
+                        message = $"This is compatible with the current game version.",
+                        details = subscribedMod.StabilityNote,
+                    };
+                case Enums.Stability.NotReviewed:
+                case Enums.Stability.Undefined:
+                    string updatedText2 = subscribedMod.GameVersion() < Toolkit.CurrentMajorGameVersion() 
+                        ? "."
+                        : subscribedMod.GameVersion() == Toolkit.CurrentGameVersion() 
+                            ? ", but it was updated for the current game version." 
+                            : $", but it was updated for game version {subscribedMod.GameVersion().ToString(2)}.";
+                    return new Message() { message = $"This mod has not been reviewed yet{updatedText2}", };
+                default:
+                    return null;
+            }
+        }
+
+
+        /// <summary>Creates report MessageList object for the statuses of a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <remarks>Also reported: retired author. DependencyMod has its own method. ModNamesDiffer is reported in the mod note (at Catalog.ScanSubscriptions()).
+        ///          Not reported: UnlistedInWorkshop, SourceObfuscated.</remarks>
+        /// <returns>Message list, or an empty string if no reported status found.</returns>
+        private MessageList Statuses(Mod subscribedMod, bool authorRetired)
+        {
+            var nestedItem = new MessageList() { messages = new List<Message>() };
+            
+            if (subscribedMod.Statuses.Contains(Enums.Status.Obsolete))
+            {
+                subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                nestedItem.title = "Unsubscribe this. It is no longer needed.";
+            }
+            else if (subscribedMod.Statuses.Contains(Enums.Status.RemovedFromWorkshop))
+            {
+                subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MajorIssues);
+                nestedItem.title = "Unsubscribe would be wise. This is no longer available on the Steam Workshop.";
+            }
+            else if (subscribedMod.Statuses.Contains(Enums.Status.Deprecated))
+            {
+                subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MajorIssues);
+                nestedItem.title = "Unsubscribe would be wise. This is deprecated and no longer supported by the author.";
+            }
+            else if (subscribedMod.Statuses.Contains(Enums.Status.Abandoned))
+            {
+                nestedItem.title = authorRetired 
+                    ? "This seems to be abandoned and the author seems retired. Future updates are unlikely."
+                    : "This seems to be abandoned. Future updates are unlikely.";
+            }
+            else if (authorRetired)
+            {
+                nestedItem.title = "The author seems to be retired. Future updates are unlikely.";
+            }
+
+            if (subscribedMod.ReportSeverity < Enums.ReportSeverity.Unsubscribe)
+            {
+                // Several statuses only listed if there are no breaking issues.
+                if (subscribedMod.Statuses.Contains(Enums.Status.Reupload))
+                {
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                    nestedItem.messages.Add(new Message(){message = "Unsubscribe this. It is a re-upload of another mod, use that one instead (or its successor)."});
+                }
+
+                if (subscribedMod.Statuses.Contains(Enums.Status.NoDescription))
+                {
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MinorIssues);
+                    nestedItem.messages.Add(new Message(){message = "This has no description on the Steam Workshop. Support from the author is unlikely."});
+                }
+
+                if (subscribedMod.Statuses.Contains(Enums.Status.NoCommentSection))
+                {
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MinorIssues);
+                    nestedItem.messages.Add(new Message(){message = "This mod has the comment section disabled on the Steam Workshop, making it hard to see if other users are experiencing issues. " +
+                        "Use with caution."});
+                }
+
+                if (subscribedMod.Statuses.Contains(Enums.Status.BreaksEditors))
+                {
+                    subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+                    nestedItem.messages.Add(new Message(){message = "If you use the asset editor and/or map editor, this may give serious issues."});
+                }
+
+                if (subscribedMod.Statuses.Contains(Enums.Status.ModForModders))
+                {
+                    nestedItem.messages.Add(new Message(){message = "This is only needed for modders. Regular users don't need this one."});
+                }
+
+                if (subscribedMod.Statuses.Contains(Enums.Status.TestVersion))
+                {
+                    nestedItem.messages.Add(new Message(){message = "This is a test version" +
+                        (subscribedMod.Alternatives.Any() ? ". If you don't have a specific reason to use it, you'd better use the stable version instead." :
+                        subscribedMod.Stability == Enums.Stability.Stable ? ", but is considered quite stable." : ".")});
+                }
+
+                if (subscribedMod.Statuses.Contains(Enums.Status.MusicCopyrightFree))
+                {
+                    nestedItem.messages.Add(new Message(){message = "The included music is said to be copyright-free and safe for streaming. Some restrictions might still apply though."});
+                }
+                else if (subscribedMod.Statuses.Contains(Enums.Status.MusicCopyrighted))
+                {
+                    nestedItem.messages.Add(new Message(){message = "This includes copyrighted music and should not be used for streaming."});
+                }
+                else if (subscribedMod.Statuses.Contains(Enums.Status.MusicCopyrightUnknown))
+                {
+                    nestedItem.messages.Add(new Message(){message = "This includes music with unknown copyright status. Safer not to use it for streaming."});
+                }
+            }
+
+            if (subscribedMod.Statuses.Contains(Enums.Status.SavesCantLoadWithout))
+            {
+                    nestedItem.messages.Add(new Message(){message = "NOTE: After using this mod, savegames won't (easily) load without it anymore."});
+            }
+
+            bool abandoned = subscribedMod.Statuses.Contains(Enums.Status.Obsolete) || subscribedMod.Statuses.Contains(Enums.Status.Deprecated) ||
+                subscribedMod.Statuses.Contains(Enums.Status.RemovedFromWorkshop) || subscribedMod.Statuses.Contains(Enums.Status.Abandoned) ||
+                (subscribedMod.Stability == Enums.Stability.IncompatibleAccordingToWorkshop) || authorRetired;
+
+            if (abandoned && string.IsNullOrEmpty(subscribedMod.SourceUrl) && !subscribedMod.Statuses.Contains(Enums.Status.SourceBundled))
+            {
+                nestedItem.messages.Add(new Message(){message = "No public source code found, making it hard to continue by another modder."});
+            }
+            else if (abandoned && subscribedMod.Statuses.Contains(Enums.Status.SourceNotUpdated))
+            {
+                nestedItem.messages.Add(new Message(){message = "Published source seems out of date, making it hard to continue by another modder."});
+            }
+
+            if (!string.IsNullOrEmpty(nestedItem.title) || nestedItem.messages.Count > 0)
+            {
+                subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+            }
+
+            return nestedItem;
+        }
+
+        /// <summary>Creates report text for an unneeded dependency mod and increases the report severity for the mod if appropriate.</summary>
+        /// <remarks>If this mod is a member of a group, all group members are considered for this check.</remarks>
+        /// <returns>Text wrapped in Message object or null if this is not a dependency mod or if another subscription has this mod as required.</returns>
+        private Message UnneededDependencyMod2(Mod subscribedMod)
+        {
+            if (!subscribedMod.Statuses.Contains(Enums.Status.DependencyMod))
+            {
+                return null;
+            }
+
+            // Check if any of the mods that need this is actually subscribed, enabled or not. If this is in a group, check all group members. Exit if any is needed.
+            if (catalog.IsGroupMember(subscribedMod.SteamID))
+            {
+                foreach (ulong groupMemberID in catalog.GetThisModsGroup(subscribedMod.SteamID).GroupMembers)
+                {
+                    if (IsModNeeded(groupMemberID))
+                    {
+                        // Group member is needed. No need to check other group members.
+                        return null;
+                    }
+                }
+            }
+            else if (IsModNeeded(subscribedMod.SteamID))
+            {
+                return null;
+            }
+
+            if (catalog.IsValidID(ModSettings.LowestLocalModID))
+            {
+                subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+
+                return new Message()
+                {
+                    message = "Unsubscribe this unless it's needed for one of your local mods. " +
+                        "None of your Steam Workshop mods need this, and it doesn't provide any functionality on its own."
+                };
+            }
+            else
+            {
+                subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                return new Message() { message = "Unsubscribe this. It is only needed for mods you don't have, and it doesn't provide any functionality on its own." };
+            }
+        }
+
+
+        /// <summary>Checks if any of the mods that need this is actually subscribed, enabled or not.</summary>
+        /// <returns>True if a mod needs this, otherwise false.</returns>
+        private bool IsModNeeded(ulong SteamID)
+        {
+            // Check if any of the mods that need this is actually subscribed, enabled or not.
+            List<Mod> ModsRequiringThis = catalog.Mods.FindAll(x => x.RequiredMods.Contains(SteamID));
+
+            foreach (Mod mod in ModsRequiringThis)
+            {
+                if (catalog.GetSubscription(mod.SteamID) != null)
+                {
+                    // Found a subscribed mod that needs this.
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Creates report text for a disabled mod and increases the report severity for the mod if appropriate.</summary>
+        /// <returns>Text wrapped in Message object, or an empty string if not disabled or if this mod works while disabled.</returns>
+        private Message Disabled(Mod subscribedMod)
+        {
+            if (!subscribedMod.IsDisabled || subscribedMod.Statuses.Contains(Enums.Status.WorksWhenDisabled))
+            {
+                return null;
+            }
+
+            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+
+            return new Message() {message = "Enable this if you want to use it, or unsubscribe it. Disabled mods can cause issues."};
+        }
+
+
+        /// <summary>Creates report text for a mod not and increases the report severity for the mod if appropriate.</summary>
+        /// <returns>Formatted text, or an empty string if no mod note exists.</returns>
+        private string ModNote(Mod subscribedMod)
+        {
+            if (string.IsNullOrEmpty(subscribedMod.Note))
+            {
+                return "";
+            }
+
+            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+
+            return subscribedMod.Note;
+        }
+
+
+        /// <summary>Creates report text for missing DLCs for a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <returns>Text wrapped in Message object, or null if no DLC is required or if all required DLCs are installed.</returns>
+        private MessageList RequiredDlc(Mod subscribedMod)
+        {
+            var dlcs = new MessageList()
+            {
+                title = "Unsubscribe this. It requires DLC you don't have:",
+                messages = new List<Message>()
+            };
+
+            foreach (Enums.Dlc dlc in subscribedMod.RequiredDlcs)
+            {
+                if (!PlatformService.IsDlcInstalled((uint)dlc))
+                {
+                    // Add the missing DLC.
+                    dlcs.messages.Add(new Message() {message = Toolkit.ConvertDlcToString(dlc)});
+                }
+            }
+
+            if (dlcs.messages.Count == 0)
+            {
+                return null;
+            }
+
+            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+
+            return dlcs;
+        }
+        
+        /// <summary>Creates report text for missing 'required mods' for a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <remarks>If a required mod is not subscribed but in a group, the other group members are checked. 
+        ///          Required mods that are disabled are mentioned as such.</remarks>
+        /// <returns>MessageList object filled with messages, or null if this requires no other mods or all required mods are subscribed and enabled.</returns>
+        private MessageList RequiredMods(Mod subscribedMod)
+        {
+            var item = new MessageList()
+            {
+                title = "This mod requires other mods you don't have, or which are not enabled:",
+                messages = new List<Message>()
+            };
+
+            foreach (ulong steamID in subscribedMod.RequiredMods)
+            {
+                if (catalog.IsValidID(steamID))
+                {
+                    var mod = ModAndGroupItem(steamID);
+                    if (mod != null)
+                    {
+                        item.messages.Add(mod);
+                    }
+                }
+                else
+                {
+                    // Mod not found in the catalog, which should not happen unless bugs or a manual edit of the catalog.
+                    Logger.Log($"Required mod {steamID} not found in catalog.", Logger.Debug);
+                    item.messages.Add(new Message() {message = $"[Steam ID {steamID,10}]"});
+                }
+            }
+
+            if (item.messages.Count == 0)
+            {
+                return null;
+            }
+
+            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MajorIssues);
+
+            return item;
+        }
+
+        /// <summary>Creates report text for recommended mods for a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <remarks>If a recommended mod is not subscribed but in a group, the other group members are checked. 
+        ///          Recommended mods that are disabled are mentioned as such.</remarks>
+        /// <returns>MessageList object filled with messages, or null if this mod has no recommendations or all recommended mods are subscribed and enabled.</returns>
+        private MessageList Recommendations2(Mod subscribedMod)
+        {
+            MessageList list = new MessageList
+            {
+                title = "The author or the users of this mod recommend using the following as well:",
+                messages = new List<Message>()
+            };
+            
+            foreach (ulong steamID in subscribedMod.Recommendations)
+            {
+                if (catalog.IsValidID(steamID))
+                {
+                    var item = ModAndGroupItem(steamID);
+                    if (item != null)
+                    {
+                        list.messages.Add(item);
+                    }
+                }
+                else
+                {
+                    // Mod not found in the catalog, which should not happen unless bugs or a manual edit of the catalog.
+                    Logger.Log($"Recommended mod {steamID} not found in catalog.", Logger.Debug);
+
+                    list.messages.Add(new Message() {message = $"[Steam ID {steamID,10}]"});
+                }
+            }
+
+            if (list.messages.Count == 0)
+            {
+                return null;
+            }
+
+            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+
+            return list;
+        }
+        
+        /// <summary>Checks if a mod or any member of its group is subscribed and enabled.</summary>
+        /// <returns>A Message with text for the report, or null if the mod or another group member is subscribed and enabled.</returns>
+        private Message ModAndGroupItem(ulong steamID)
+        {
+            Mod catalogMod = catalog.GetSubscription(steamID);
+
+            if (catalogMod != null && (!catalogMod.IsDisabled || catalogMod.Statuses.Contains(Enums.Status.WorksWhenDisabled)))
+            {
+                // Mod is subscribed and enabled (or works when disabled). Don't report.
+                return null;
+            }
+            catalogMod = catalog.GetMod(steamID);
+
+            if (catalogMod.IsDisabled)
+            {
+                // Mod is subscribed and disabled. Report as "missing", without Workshop page.
+                return new Message() { message = catalog.GetMod(steamID).ToString(hideFakeID: true) };
+            }
+
+            if (!catalog.IsGroupMember(steamID))
+            {
+                // Mod is not subscribed and not in a group. Report as missing with Workshop page.
+                return new Message() { message = catalogMod.NameWithIDAsLink(true, false) };
+            }
+            
+            // Mod is not subscribed but in a group. Check if another group member is subscribed.
+            foreach (ulong groupMemberID in catalog.GetThisModsGroup(steamID).GroupMembers)
+            {
+                Mod groupMember = catalog.GetSubscription(groupMemberID);
+
+                if (groupMember != null)
+                {
+                    // Group member is subscribed. No need to check other group members, but report as "missing" if disabled (unless it works when disabled).
+                    if (!groupMember.IsDisabled || groupMember.Statuses.Contains(Enums.Status.WorksWhenDisabled))
+                    {
+                        return null;
+                    }
+                    return new Message() { message = groupMember.ToString(hideFakeID: true) };
+                }
+            }
+
+            // No group member is subscribed. Report original mod as missing.
+            return new Message() { message = catalogMod.NameWithIDAsLink(true, false) };
+        }
+
+        /// <summary>Creates report text for successors of a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <returns>Text wrapped in Message object, or null if this mod has no successors.</returns>
+        private MessageList Successors(Mod subscribedMod)
+        {
+            if (!subscribedMod.Successors.Any())
+            {
+                return null;
+            }
+
+            MessageList successors = new MessageList();
+            successors.title = (subscribedMod.Successors.Count == 1)
+                ? "This is succeeded by:"
+                : "This is succeeded by any of the following (pick one, not all):";
+
+            List<Message> successorsCollection = new List<Message>();
+            successors.messages = successorsCollection;
+
+            foreach (ulong steamID in subscribedMod.Successors)
+            {
+                Message s = new Message();
+                if (catalog.IsValidID(steamID))
+                {
+                    if (catalog.GetSubscription(steamID) != null)
+                    {
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+
+                        s.message = "Unsubscribe this. It is succeeded by a mod you already have:";
+                        s.details = catalog.GetMod(steamID).ToString(hideFakeID: true);
+                        successorsCollection.Add(s);
+                        return successors;
+                    }
+
+                    s.message = catalog.GetMod(steamID).ToString(hideFakeID: true);
+                    s.details = $"Workshop page: {HtmlExtensions.A(Toolkit.GetWorkshopUrl(steamID))}";
+                    successorsCollection.Add(s);
+                }
+                else
+                {
+                    // Mod not found in the catalog, which should not happen unless bugs or a manual edit of the catalog.
+                    Logger.Log($"Successor mod {steamID} not found in catalog.", Logger.Debug);
+
+                    s.message = $"[Steam ID {steamID,10}]";
+                    successorsCollection.Add(s);
+                }
+            }
+
+            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MinorIssues);
+
+            return successors;
+        }
+        
+        /// <summary>Creates report text for alternatives for a mod and increases the report severity for the mod if appropriate.</summary>
+        /// <returns>Text wrapped in Message object, or null if this mod has no alternatives.</returns>
+        private MessageList Alternatives(Mod subscribedMod)
+        {
+            if (!subscribedMod.Alternatives.Any())
+            {
+                return null;
+            }
+            
+            var result = new MessageList()
+            {
+                title = subscribedMod.Alternatives.Count == 1 
+                    ? "An alternative you could use:"
+                    : "Some alternatives for this are (pick one, not all):",
+                messages = new List<Message>()
+            };
+
+            foreach (ulong steamID in subscribedMod.Alternatives)
+            {
+                Mod alternativeMod = catalog.GetSubscription(steamID);
+
+                if (alternativeMod != null && (!alternativeMod.IsDisabled || alternativeMod.Statuses.Contains(Enums.Status.WorksWhenDisabled)))
+                {
+                    // Already subscribed, don't report any.
+                    return null;
+                }
+
+                if (catalog.IsValidID(steamID))
+                {
+                    result.messages.Add(new Message(){message = catalog.GetMod(steamID).NameWithIDAsLink(true, false)});
+                }
+                else
+                {
+                    // Mod not found in the catalog, which should not happen unless bugs or a manual edit of the catalog.
+                    Logger.Log($"Alternative mod {steamID} not found in catalog.", Logger.Debug);
+
+                    result.messages.Add(new Message(){message = $"[Steam ID {steamID,10}]"});
+                }
+            }
+
+            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+
+            return result;
+        }
+        
+        /// <summary>Creates report text for compatibility issues with other subscribed mods, and increases the report severity for the mod if appropriate.</summary>
+        /// <remarks>Result could be multiple mods with multiple statuses. Not reported: CompatibleAccordingToAuthor.</remarks>
+        /// <returns>Text wrapped in Message object, or null if there are no known compatibility issues.</returns>
+        private MessageList Compatibilities(Mod subscribedMod)
+        {
+
+            var result = new MessageList()
+            {
+                title = string.Empty,
+                messages = new List<Message>()
+            };
+            
+            foreach (Compatibility compatibility in catalog.GetSubscriptionCompatibilities(subscribedMod.SteamID))
+            {
+                ulong otherModID = (subscribedMod.SteamID == compatibility.FirstModID) ? compatibility.SecondModID : compatibility.FirstModID;
+
+                Mod otherMod = catalog.GetMod(otherModID);
+                if (subscribedMod.Successors.Contains(otherModID) || otherMod == null || otherMod.Successors.Contains(subscribedMod.SteamID))
+                {
+                    // Don't mention the incompatibility if either mod is the others successor. The succeeded mod will already be mentioned in 'Unsubscribe' severity.
+                    continue;
+                }
+
+                string otherModString = catalog.GetMod(otherModID).NameWithIDAsLink(false, idFirst: false);
+
+                Message item = new Message();
+                
+                switch (compatibility.Status)
+                {
+                    case Enums.CompatibilityStatus.SameModDifferentReleaseType:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                        item.message = "Unsubscribe either this or the other edition of the same mod:";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.SameFunctionality:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                        item.message = "Unsubscribe either this or the following incompatible mod with similar functionality:";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.IncompatibleAccordingToAuthor:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Unsubscribe);
+                        item.message = "Unsubscribe either this one or the following mod it's incompatible with:";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.IncompatibleAccordingToUsers:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MajorIssues);
+                        item.message = "Users report an incompatibility with:";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.MajorIssues:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MajorIssues);
+                        item.message = "This has major issues with:";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.MinorIssues:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.MinorIssues);
+                        item.message = "This has minor issues with:";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.RequiresSpecificSettings:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+                        item.message = "This requires specific configuration to work together with:";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.SameFunctionalityCompatible:
+                        subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+                        item.message = "This has very similar functionality, but is still compatible with (do you need both?):";
+                        item.details = otherModString + compatibility.Note;
+                        break;
+
+                    case Enums.CompatibilityStatus.CompatibleAccordingToAuthor:
+                        if (!string.IsNullOrEmpty(compatibility.Note))
+                        {
+                            subscribedMod.IncreaseReportSeverity(Enums.ReportSeverity.Remarks);
+                            item.message = "This is compatible with:";
+                            item.details = otherModString + compatibility.Note;
+                        }
+                        break;
+
+                    default:
+                        break;
+                }
+                
+                result.messages.Add(item);
+            }
+
+            return result;
+        }
+
+        private class ModInfo
+        {
+            public bool isLocal;
+            public string authorName;
+            public string modName;
+            public string idString;
+            public bool isDisabled;
+            public bool isCameraScript;
+            public Enums.ReportSeverity reportSeverity;
+            public Message instability;
+            public MessageList requiredDlc;
+            public Message unneededDependencyMod;
+            public Message disabled;
+            public MessageList successors;
+            public Message stability;
+            public MessageList compatibilities;
+            public MessageList requiredMods;
+            public MessageList statuses;
+            public string note;
+            public MessageList alternatives;
+            public MessageList recommendations;
+            public bool anyIssues;
+            public string steamUrl;
+        }
+
+        private class InstalledModInfo
+        {
+            public string disabled;
+            public bool isSteam;
+
+            public string subscriptionName;
+            public string type;
+            public string url;
+
+            internal InstalledModInfo(string subscriptionName, string disabled, string type, bool isSteam, string url)
+            {
+                this.subscriptionName = subscriptionName;
+                this.disabled = disabled;
+                this.type = type;
+                this.isSteam = isSteam;
+                this.url = url;
+            }
+        }
+    }
+
+    internal class MessageList
+    {
+        public string title;
+        public List<Message> messages;
+    }
+
+    internal class Message
+    {
+        public string message;
+        public string details;
+    }
+}

--- a/CompatibilityReport/Reporter/Report.cs
+++ b/CompatibilityReport/Reporter/Report.cs
@@ -1,6 +1,9 @@
-﻿using ColossalFramework.PlatformServices;
+﻿using System.IO;
+using ColossalFramework.PlatformServices;
 using ColossalFramework.Plugins;
 using CompatibilityReport.CatalogData;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Settings.ConfigData;
 using CompatibilityReport.Util;
 
 namespace CompatibilityReport.Reporter
@@ -11,19 +14,19 @@ namespace CompatibilityReport.Reporter
 
 
         /// <summary>Starts the reporter to create a text and/or HTML report.</summary>
-        public static void Create(string scene)
+        public static void Create(string scene, bool force = false)
         {
-            if (hasRun)
+            if (hasRun && !force)
             {
                 return;
             }
-            
+
             hasRun = true;
 
             // Remove the debug logfile from a previous session, if it exists.
-            if (!ModSettings.DebugMode)
+            if (!GlobalConfig.Instance.AdvancedConfig.DebugMode)
             {
-                Toolkit.DeleteFile(System.IO.Path.Combine(ModSettings.DebugLogPath, ModSettings.LogFileName));
+                Toolkit.DeleteFile(Path.Combine(ModSettings.DebugLogPath, ModSettings.LogFileName));
             }
 
             Logger.Log($"{ ModSettings.ModName } version { ModSettings.FullVersion }. Game version { Toolkit.ConvertGameVersionToString(Toolkit.CurrentGameVersion()) }.");
@@ -58,13 +61,15 @@ namespace CompatibilityReport.Reporter
             catalog.ScanSubscriptions();
             Logger.Log($"Reviewed { catalog.ReviewedSubscriptionCount } of your { catalog.SubscriptionCount() } mods.");
 
-            if (ModSettings.HtmlReport)
+            GeneralConfig modConfig = GlobalConfig.Instance.GeneralConfig;
+            if (modConfig.HtmlReport)
             {
-                // Todo 1.1 Create HTML report.
+                HtmlReport htmlReport = new HtmlReport(catalog);
+                htmlReport.Create();
             }
 
             // Always create the text report if the HTML report is disabled, so at least one report is created.
-            if (ModSettings.TextReport || !ModSettings.HtmlReport)
+            if (modConfig.TextReport || !modConfig.HtmlReport)
             {
                 TextReport textReport = new TextReport(catalog);
                 textReport.Create();

--- a/CompatibilityReport/Reporter/TextReport.cs
+++ b/CompatibilityReport/Reporter/TextReport.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using ColossalFramework.PlatformServices;
 using CompatibilityReport.CatalogData;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Settings.ConfigData;
 using CompatibilityReport.Util;
 
 namespace CompatibilityReport.Reporter
@@ -55,10 +57,11 @@ namespace CompatibilityReport.Reporter
 
             AddFooter();
 
-            string textReportFullPath = Path.Combine(ModSettings.ReportPath, ModSettings.ReportTextFileName);
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            string textReportFullPath = Path.Combine(config.ReportPath, ModSettings.ReportTextFileName);
             Toolkit.DeleteFile($"{ textReportFullPath }.old");
 
-            if (Toolkit.SaveToFile(reportText.ToString(), textReportFullPath, createBackup: ModSettings.DebugMode))
+            if (Toolkit.SaveToFile(reportText.ToString(), textReportFullPath, createBackup: GlobalConfig.Instance.AdvancedConfig.DebugMode))
             {
                 Logger.Log($"Text Report ready at \"{ Toolkit.Privacy(textReportFullPath) }\".");
                 return;
@@ -68,7 +71,7 @@ namespace CompatibilityReport.Reporter
 
             string altTextReportFullPath = Path.Combine(ModSettings.DefaultReportPath, ModSettings.ReportTextFileName);
             Toolkit.DeleteFile($"{ altTextReportFullPath }.old");
-            if ((ModSettings.ReportPath != ModSettings.DefaultReportPath) && Toolkit.SaveToFile(reportText.ToString(), altTextReportFullPath))
+            if ((config.ReportPath != ModSettings.DefaultReportPath) && Toolkit.SaveToFile(reportText.ToString(), altTextReportFullPath))
             {
                 Logger.Log($"Text Report could not be saved to the location set in the options. It is instead saved as \"{ Toolkit.Privacy(altTextReportFullPath) }\".", 
                     Logger.Warning);
@@ -202,7 +205,7 @@ namespace CompatibilityReport.Reporter
         /// <summary>Adds the report text for all mods to the report.</summary>
         private void AddAllMods()
         {
-            if (ModSettings.ReportSortByName)
+            if (GlobalConfig.Instance.GeneralConfig.ReportSortByName)
             {
                 // Report mods sorted by name.
                 List<string> AllSubscriptionNames = catalog.GetSubscriptionNames();

--- a/CompatibilityReport/Reporter/TextReport.cs
+++ b/CompatibilityReport/Reporter/TextReport.cs
@@ -133,6 +133,12 @@ namespace CompatibilityReport.Reporter
                     "be detected correctly by other mods.\n", indent: new string(' ', "NOTE: ".Length)));
             }
 
+            if (catalog.FakeSubscriptionCount != 0)
+            {
+                reportText.AppendLine(Toolkit.WordWrap($"NOTE: The report includes { catalog.FakeSubscriptionCount } fake " +
+                    $"subscription{ (catalog.FakeSubscriptionCount == 1 ? "" : "s") }\n", indent: new string(' ', "NOTE: ".Length)));
+            }
+
             int nonReviewedSubscriptions = catalog.SubscriptionCount() - catalog.ReviewedSubscriptionCount - catalog.LocalSubscriptionCount;
 
             if (nonReviewedSubscriptions != 0)

--- a/CompatibilityReport/Settings/ConfigData/AdvancedConfig.cs
+++ b/CompatibilityReport/Settings/ConfigData/AdvancedConfig.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace CompatibilityReport.Settings.ConfigData
+{
+    [Serializable]
+    public class AdvancedConfig
+    {
+        public int DownloadRetries { get; set; } = 4;
+        public bool ScanBeforeMainMenu { get; set; } = true;
+        public bool DebugMode { get; set; } = false;
+        public long LogMaxSize { get; set; } = 100 * 1024;
+    }
+}

--- a/CompatibilityReport/Settings/ConfigData/GeneralConfig.cs
+++ b/CompatibilityReport/Settings/ConfigData/GeneralConfig.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace CompatibilityReport.Settings.ConfigData
+{
+    [Serializable]
+    public class GeneralConfig
+    {
+        private const int MinimalTextReportWidth = 90;
+        internal static string DefaultReportPath { get; } = UnityEngine.Application.dataPath;
+ 
+        /// <summary>
+        /// Configurable path where html and text reports will be stored
+        /// </summary>
+        public string ReportPath { get; set; } = DefaultReportPath;
+        
+        public bool ReportSortByName { get; set; } = true;
+        
+        public int TextReportWidth { get; set; } = MinimalTextReportWidth;
+        
+        /// <summary>
+        /// Generate html report
+        /// </summary>
+        public bool HtmlReport { get; set; } = false;
+        /// <summary>
+        /// Generate text report, will be force if html report disabled
+        /// </summary>
+        public bool TextReport { get; set; } = true;
+        
+        /// <summary>
+        /// Open Html report using Steam Overlay if available
+        /// </summary>
+        public bool OpenHtmlReportInSteamOverlay { get; set; } = false;
+        
+        /// <summary>
+        /// "text", "html", "text and html"
+        /// </summary>
+        public int ReportType { get; set; } = 0;
+        
+        /// <summary>
+        /// 0: "Once a week", 1: "Never (on-demand only) - not recommended!"
+        /// </summary>
+        public int DownloadFrequency { get; set; } = 0;
+
+        public static string DownloadFrequencyToString(int frequency)
+        {
+            switch (frequency)
+            {
+                case 0:
+                    return "Once a week";
+                case 1:
+                    return "Never (on-demand only)";
+                default:
+                    return $"Not supported: {frequency}";
+            }
+        }
+    }
+}

--- a/CompatibilityReport/Settings/ConfigData/UpdaterConfig.cs
+++ b/CompatibilityReport/Settings/ConfigData/UpdaterConfig.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace CompatibilityReport.Settings.ConfigData
+{
+    [Serializable]
+    public class UpdaterConfig
+    {
+        public int SteamMaxFailedPages { get; set; } = 4;
+        public int SteamMaxListingPages { get; set; } = 300;
+        public int EstimatedMillisecondsPerModPage { get; set; } = 500;
+        public int DaysOfInactivityToRetireAuthor { get; set; } = 365;
+        public int WeeksForSoonRetired { get; set; } = 2;
+    }
+}

--- a/CompatibilityReport/Settings/GlobalConfig.cs
+++ b/CompatibilityReport/Settings/GlobalConfig.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.IO;
+using System.Xml.Serialization;
+using ColossalFramework.IO;
+using CompatibilityReport.Settings.ConfigData;
+using CompatibilityReport.Util;
+
+namespace CompatibilityReport.Settings
+{
+    public class GlobalConfig
+    {
+        private const string SettingsFileName = ModSettings.InternalName + "_Settings.xml";
+        private static string SettingsPath { get; } = DataLocation.applicationBase;
+        public static GlobalConfig Instance { get; private set; }
+
+        public GeneralConfig GeneralConfig = new GeneralConfig();
+        public UpdaterConfig UpdaterConfig = new UpdaterConfig();
+        public AdvancedConfig AdvancedConfig = new AdvancedConfig();
+        
+        static GlobalConfig()
+        {
+            Reload();
+        }
+        
+        internal static void Ensure()
+        {
+        }
+
+        internal static void WriteConfig()
+        {
+            WriteConfig(Instance);
+        }
+
+        internal static void Reload()
+        {
+            Instance = Load();
+        }
+
+        internal static void Reset()
+        {
+            GlobalConfig config = new GlobalConfig();
+            WriteConfig(config);
+            Instance = config;
+        }
+
+        private static GlobalConfig Load()
+        {
+            try
+            {
+                // use game log explicitly since mod logger is accessing GlobalConfig - not available at first load
+                UnityEngine.Debug.Log($"[{ModSettings.InternalName}] Loading mod config from file '{SettingsFileName}'...");
+                using (FileStream fs = new FileStream(Path.Combine(SettingsPath, SettingsFileName), FileMode.Open))
+                {
+                    XmlSerializer serializer = new XmlSerializer(typeof(GlobalConfig));
+                    UnityEngine.Debug.Log($"[{ModSettings.InternalName}] Mod config loaded.");
+                    GlobalConfig conf = (GlobalConfig)serializer.Deserialize(fs);
+                    if (conf.GeneralConfig == null)
+                    {
+                        conf.GeneralConfig = new GeneralConfig();
+                    }
+
+                    if (conf.UpdaterConfig == null)
+                    {
+                        conf.UpdaterConfig = new UpdaterConfig();
+                    }
+                    
+                    if (conf.AdvancedConfig == null)
+                    {
+                        conf.AdvancedConfig = new AdvancedConfig();
+                    }
+                    
+                    return conf;
+                }
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning($"[{ModSettings.InternalName}] Could not load global config: {e} Generating default config.");
+                GlobalConfig config = new GlobalConfig();
+                WriteConfig(config);
+                return config;
+            }
+        }
+
+        private static void WriteConfig(GlobalConfig config)
+        {
+            try
+            {
+                Logger.Log($"Writing global config to file '{SettingsFileName}'...");
+                XmlSerializer serializer = new XmlSerializer(typeof(GlobalConfig));
+                using (TextWriter writer = new StreamWriter(Path.Combine(SettingsPath, SettingsFileName)))
+                {
+                    serializer.Serialize(writer, config);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Could not write global config: {e}", Logger.LogLevel.Error);
+            }
+        }
+    }
+}

--- a/CompatibilityReport/Settings/SettingsManager.cs
+++ b/CompatibilityReport/Settings/SettingsManager.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using ColossalFramework.PlatformServices;
+using CompatibilityReport.CatalogData;
+using CompatibilityReport.Reporter;
+using CompatibilityReport.Settings.ConfigData;
+using CompatibilityReport.UI;
+using CompatibilityReport.Updater;
+using CompatibilityReport.Util;
+using UnityEngine.SceneManagement;
+
+namespace CompatibilityReport.Settings
+{
+    internal static class SettingsManager
+    {
+
+        public static event Action eventCatalogUpdated;
+        private static bool SteamOverlayAvailable
+            => PlatformService.platformType == PlatformType.Steam &&
+                PlatformService.IsOverlayEnabled();
+
+        private static void OpenURL(string url) {
+            if (string.IsNullOrEmpty(url)) return;
+
+            bool useSteamOverlay =
+                SteamOverlayAvailable &&
+                GlobalConfig.Instance.GeneralConfig.OpenHtmlReportInSteamOverlay;
+
+            if (useSteamOverlay) {
+                PlatformService.ActivateGameOverlayToWebPage(url);
+            } else {
+                Process.Start(url);
+            }
+        }
+
+        internal static void OnDownloadOptionChanged(int sel)
+        {           
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            if (config.DownloadFrequency != sel)
+            {
+                config.DownloadFrequency = sel;
+                GlobalConfig.WriteConfig();
+            }
+        }
+
+        /// <summary>
+        /// Notifies subscribers about updated catalog (mostly UI)
+        /// </summary>
+        internal static void NotifyCatalogUpdated()
+        {
+            eventCatalogUpdated?.Invoke();
+        }
+
+        internal static void OnDownloadCatalog()
+        {
+            Catalog.Load(true);
+        }
+
+        internal static void OnOpenReports()
+        {
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            if (config.HtmlReport)
+            {
+                OpenURL(Path.Combine(config.ReportPath, ModSettings.ReportHtmlFileName));
+            }
+            if (config.TextReport)
+            {
+                OpenURL(Path.Combine(config.ReportPath, ModSettings.ReportTextFileName));
+            }
+        }
+
+        internal static void OnReportTypeChange(int sel)
+        {
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            config.ReportType = sel;
+            switch (sel)
+            {
+                case 0:
+                    config.TextReport = true;
+                    config.HtmlReport = false;
+                    break;
+                case 1:
+                    config.TextReport = false;
+                    config.HtmlReport = true;
+                    break;
+                case 2:
+                    config.TextReport = true;
+                    config.HtmlReport = true;
+                    break;
+                default:
+                    config.TextReport = true;
+                    config.HtmlReport = false;
+                    break;
+            }
+            GlobalConfig.WriteConfig();
+        }
+
+        internal static void OnChangeReportPath(string text)
+        {
+            string currentPath = GlobalConfig.Instance.GeneralConfig.ReportPath;
+            if (currentPath != text)
+            {
+                GlobalConfig.Instance.GeneralConfig.ReportPath = text;
+                GlobalConfig.WriteConfig();
+            }
+        }
+
+        internal static void OnResetReportPath()
+        {
+            GlobalConfig.Instance.GeneralConfig.ReportPath = GeneralConfig.DefaultReportPath;
+            GlobalConfig.WriteConfig();
+        }
+
+        internal static void OnGenerateReports()
+        {
+            Report.Create(SceneManager.GetActiveScene().name, force: true);
+        }
+
+        internal static void OnResetAllSettings()
+        {
+            GlobalConfig.Reset();
+        }
+
+        public static void OnReloadCatalogFromDisk()
+        {
+            
+        }
+
+        public static void OnOpenHtmlReportInSteamChanged(bool ischecked)
+        {
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            if (config.OpenHtmlReportInSteamOverlay != ischecked)
+            {
+                config.OpenHtmlReportInSteamOverlay = ischecked;
+                GlobalConfig.WriteConfig();
+            }
+        }
+
+        public static void OnStartWebCrawler(ProgressMonitorUI progressUI)
+        {
+            ProgressMonitor monitor = new ProgressMonitor(progressUI);
+            progressUI.Title = "Web Crawler progress";
+            monitor.PushMessage("Web Crawler: Loading Catalog...");
+            monitor.eventDisposed += () => {
+                progressUI.Progress = 1f;
+                progressUI.ProgressText = "Processing done.";
+                progressUI.ForceClose();
+            };
+            progressUI.StartCoroutine(WebCrawler.StartWithProgress(Catalog.Load(true), monitor));
+        }
+
+        public static void OnStartUpdater(ProgressMonitorUI progressUI)
+        {
+            ProgressMonitor monitor = new ProgressMonitor(progressUI);
+            monitor.eventDisposed += () => {
+                progressUI.Progress = 1f;
+                progressUI.ProgressText = "Processing done.";
+                progressUI.ForceClose();
+            };
+            progressUI.Title = "Updater progress";
+            progressUI.StartCoroutine(CatalogUpdater.StartWithProgress(monitor));
+        }
+
+        public static void OnOneTimeAction(ProgressMonitorUI progressUI)
+        {
+            ProgressMonitor monitor = new ProgressMonitor(progressUI);
+            monitor.eventDisposed += () => {
+                progressUI.Progress = 1f;
+                progressUI.ProgressText = "Processing done.";
+                progressUI.ForceClose();
+            };
+            progressUI.Title = "One-Time-Action progress";
+            progressUI.StartCoroutine(OneTimeAction.Start(monitor));
+        }
+
+        internal static void CleanupEvents()
+        {
+            eventCatalogUpdated = null;
+        }
+    }
+}

--- a/CompatibilityReport/Settings/SettingsManager.cs
+++ b/CompatibilityReport/Settings/SettingsManager.cs
@@ -137,7 +137,7 @@ namespace CompatibilityReport.Settings
             }
         }
 
-        public static void OnStartWebCrawler(ProgressMonitorUI progressUI)
+        public static void OnStartWebCrawler(ProgressMonitorUI progressUI, bool quick = false)
         {
             ProgressMonitor monitor = new ProgressMonitor(progressUI);
             progressUI.Title = "Web Crawler progress";
@@ -147,7 +147,7 @@ namespace CompatibilityReport.Settings
                 progressUI.ProgressText = "Processing done.";
                 progressUI.ForceClose();
             };
-            progressUI.StartCoroutine(WebCrawler.StartWithProgress(Catalog.Load(true), monitor));
+            progressUI.StartCoroutine(WebCrawler.StartWithProgress(Catalog.Load(true), monitor, quick));
         }
 
         public static void OnStartUpdater(ProgressMonitorUI progressUI)

--- a/CompatibilityReport/UI/ProgressMonitor.cs
+++ b/CompatibilityReport/UI/ProgressMonitor.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using CompatibilityReport.Settings;
+using UnityEngine;
+using Settings_1 = Settings;
+
+namespace CompatibilityReport.UI
+{
+    public class ProgressMonitor : IDisposable
+    {
+        public DateTime StartedAt { get; private set; }
+        public DateTime FinishedAt { get; private set; }
+
+        public event Action<float> eventProgressChanged;
+        public event Action eventDisposed;
+        public float CurrentProgress => currentStep / (float)numOfSteps;
+        public bool Working { get; private set; }
+
+        public bool Completed { get; private set; }
+
+        public bool Aborted { get; private set; }
+
+        public string ProgressMessage
+        {
+            get { return _progressMessage; }
+            private set {
+                if (!string.IsNullOrEmpty(value) && ProgressMessage != value)
+                {
+                    _progressMessage = value;
+                }
+            }
+        }
+        
+        private string _progressMessage = string.Empty;
+        private int numOfSteps = 1;
+        private int currentStep = 1;
+        private bool reportTime;
+
+        private ProgressMonitorUI ui;
+        
+        public ProgressMonitor(ProgressMonitorUI ui)
+        {
+            this.ui = ui;
+        }
+
+        public void StartProgress(int stepsCount, string message, bool reportTime = false)
+        {
+            if (stepsCount == 0)
+            {
+                throw new ArgumentException($"{nameof(stepsCount)} cannot be 0!");
+            }
+            numOfSteps = stepsCount;
+            currentStep = 0;
+            Working = true;
+            Completed = false;
+            Aborted = false;
+            StartedAt = DateTime.Now;
+            FinishedAt = DateTime.MinValue;
+            ProgressMessage = message;
+            if (ui)
+            {
+                this.reportTime = reportTime;
+                if (!reportTime)
+                {
+                    ui.UpdateElapsedTime(TimeSpan.Zero);
+                }
+                ui.ProgressTitle = message;
+                ui.ProgressText = message;
+            }
+            if (reportTime)
+            {
+                ui.UpdateEstimatedTime((double)GlobalConfig.Instance.UpdaterConfig.EstimatedMillisecondsPerModPage * stepsCount);
+            }
+            else
+            {
+                ui.UpdateEstimatedTime(0);
+            }
+        }
+
+        public void UpdateStage(int current, int max)
+        {
+            if (ui)
+            {
+                ui.UpdateStage(current, max);
+            }
+        }
+
+        public void ReportProgress(int step, string message = null)
+        {
+            ProgressMessage = message;
+            currentStep = step;
+            if (step == numOfSteps)
+            {
+                Working = false;
+                Completed = true;
+                FinishedAt = DateTime.Now;
+            }
+            
+            if (ui)
+            {
+                ui.Progress = CurrentProgress;
+                ui.ProgressText = message;
+                if (reportTime)
+                {
+                    ui.UpdateElapsedTime(DateTime.Now.Subtract(StartedAt));
+                }
+            }
+            eventProgressChanged?.Invoke(CurrentProgress);
+        }
+
+        public void PushMessage(string message)
+        {
+            if (ui)
+            {
+                ui.PushMessage(message);
+            }
+        }
+
+        public void Abort()
+        {
+            if (ui)
+            {
+                ui.ProgressText = "Abort!";
+            }
+            if (Working && !Completed)
+            {
+                Aborted = true;
+                Working = false;
+                FinishedAt = DateTime.Now;
+            }
+            eventProgressChanged?.Invoke(1f);
+        }
+
+        public void Dispose()
+        {
+            ui = null;
+            eventDisposed?.Invoke();
+            eventDisposed = null;
+            eventProgressChanged = null;
+        }
+    }
+}

--- a/CompatibilityReport/UI/ProgressMonitorUI.cs
+++ b/CompatibilityReport/UI/ProgressMonitorUI.cs
@@ -1,0 +1,294 @@
+﻿using System;
+using ColossalFramework;
+using ColossalFramework.UI;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace CompatibilityReport.UI
+{
+    public class ProgressMonitorUI : UIPanel
+    {
+        private const int PANEL_WIDTH = 650;
+        private const int PANEL_HEIGHT = 400;
+        private UILabel _title;
+        private UIButton _closeButton;
+        private UIDragHandle _dragHandle;
+        private UIScrollablePanel _logPanel;
+
+        private UIProgressBar _progressBar;
+        private UILabel _progressLabel;
+        private UILabel _titleLabel;
+        private UILabel _stageLabel;
+        private UILabel _estimatedTimeLabel;
+        private UILabel _elapsedLabel;
+        private UILabel _messageTemplate;
+
+        public string Title
+        {
+            set { _title.text = value ?? string.Empty; }
+        }
+
+        public float Progress
+        {
+            set { _progressBar.value = value; }
+        }
+
+        public string ProgressTitle
+        {
+            set
+            {
+                if (_titleLabel.text != value)
+                {
+                    _titleLabel.text = value;
+                }
+            }
+        }
+
+        public string ProgressText
+        {
+            set
+            {
+                if (_progressLabel.text != value)
+                {
+                    _progressLabel.text = value;
+                }
+            }
+        }
+
+        public override void Awake()
+        {
+            base.Awake();
+            autoLayout = false;
+            width = PANEL_WIDTH;
+            height = PANEL_HEIGHT;
+            backgroundSprite = "UnlockingPanel2";
+            color = new Color32(72, 104, 139, 255);
+            CreateTitle();
+            CreateDragHandle();
+            CreateCloseButton();
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            //it's already destroying itself no need to destroy gameobject again  
+            OnClose(resetOnly: true);
+        }
+
+        public void Initialize()
+        {
+            UIPanel panel = AddUIComponent<UIPanel>();
+            panel.autoLayout = false;
+            panel.width = PANEL_WIDTH;
+            panel.height = 90;
+            panel.relativePosition = new Vector3(0, 40);
+            CreateProgressBar(panel);
+            absolutePosition = new Vector3(Screen.width / 2 - 100, Screen.height / 2 - 100);
+            CreateLogPanel();
+        }
+
+        private void CreateLogPanel()
+        {
+            UIPanel panel = AddUIComponent<UIPanel>();
+            panel.size = new Vector2(PANEL_WIDTH, 200);
+            panel.autoLayout = true;
+            panel.autoLayoutDirection = LayoutDirection.Horizontal;
+            panel.relativePosition = new Vector3(0, 185);
+            
+            _logPanel = panel.AddUIComponent<UIScrollablePanel>();
+            _logPanel.builtinKeyNavigation = true;
+            _logPanel.autoLayoutDirection = LayoutDirection.Vertical;
+            _logPanel.scrollWheelDirection = UIOrientation.Vertical;
+            _logPanel.relativePosition = new Vector3(0, 0);
+            _logPanel.autoLayoutPadding = new RectOffset(15, 15, 0, 0);
+            _logPanel.size = new Vector2(PANEL_WIDTH-20, 200);
+            _logPanel.autoLayout = true;
+            _logPanel.clipChildren = true;
+            
+            UIScrollbar scrollbar = panel.AddUIComponent<UIScrollbar>();
+            scrollbar.orientation = UIOrientation.Vertical;
+            scrollbar.size = new Vector2(20, 200);
+            scrollbar.incrementAmount = 30;
+            scrollbar.scrollEasingType = EasingType.BackEaseOut;
+            scrollbar.scrollEasingTime = 2;
+            scrollbar.scrollSize = PANEL_WIDTH;
+            
+            UISlicedSprite track = scrollbar.AddUIComponent<UISlicedSprite>();
+            track.relativePosition = new Vector3(0, 0);
+            track.size = new Vector3(18, 200); 
+            track.spriteName = "ScrollbarTrack";
+            scrollbar.trackObject = track;
+            
+            UISlicedSprite thumb = track.AddUIComponent<UISlicedSprite>();
+            thumb.relativePosition = new Vector3(1, 0);
+            thumb.spriteName = "ScrollbarThumb";
+            thumb.size = new Vector2(18, 40);
+            scrollbar.thumbObject = thumb;
+            
+            _logPanel.verticalScrollbar = scrollbar;
+        }
+
+        public void ResetUI()
+        {
+            _title.text = "No Title";
+            _titleLabel.text = string.Empty;
+            _progressBar.value = 0;
+            _progressLabel.text = "Processing...";
+        }
+
+        public void PushMessage(string message)
+        {
+            if (!_messageTemplate)
+            {
+                _messageTemplate = new GameObject("ProgressMonitorUI_Message").AddComponent<UILabel>();
+                _messageTemplate.autoHeight = true;
+                _messageTemplate.minimumSize = new Vector2(PANEL_WIDTH, 15);
+                _messageTemplate.width = PANEL_WIDTH - 50;
+                _messageTemplate.text = string.Empty;
+                _messageTemplate.textScale = 0.9f;
+                _messageTemplate.wordWrap = true;
+                _messageTemplate.processMarkup = true;
+            }
+
+            GameObject messageObject = Object.Instantiate(_messageTemplate.gameObject);
+            UILabel messageLabel = _logPanel.AttachUIComponent(messageObject) as UILabel;
+            messageLabel.relativePosition = new Vector3(0, _logPanel.components.Count * 20);
+            messageLabel.text = message;
+            _logPanel.ScrollToBottom();
+        }
+
+        private void CreateDragHandle()
+        {
+            _dragHandle = AddUIComponent<UIDragHandle>();
+            _dragHandle.area = new Vector4(0, 0, PANEL_WIDTH - 40, 45);
+        }
+
+        private void CreateTitle()
+        {
+            _title = AddUIComponent<UILabel>();
+            _title.autoSize = true;
+            _title.textScale = 1.2f;
+            _title.padding = new RectOffset(0, 10, 5, 15);
+            _title.relativePosition = new Vector2(20, 8);
+            _title.text = $"No Title";
+            _title.textAlignment = UIHorizontalAlignment.Center;
+        }
+
+        private void CreateCloseButton()
+        {
+            _closeButton = AddUIComponent<UIButton>();
+            _closeButton.eventClick += CloseButtonClick;
+            _closeButton.relativePosition = new Vector3(width - _closeButton.width - 35, 5f);
+            _closeButton.normalBgSprite = "buttonclose";
+            _closeButton.hoveredBgSprite = "buttonclosehover";
+            _closeButton.pressedBgSprite = "buttonclosepressed";
+        }
+
+        private void CreateProgressBar(UIPanel progressPanel)
+        {
+            _titleLabel = progressPanel.AddUIComponent<UILabel>();
+            _titleLabel.padding = new RectOffset(15, 10, 5, 10);
+            _titleLabel.relativePosition = new Vector2(0, 0);
+            _titleLabel.text = string.Empty;
+
+            _progressBar = progressPanel.AddUIComponent<UIProgressBar>();
+            _progressBar.relativePosition = new Vector3(15, 55);
+            _progressBar.width = PANEL_WIDTH - 30;
+            _progressBar.height = 20;
+            _progressBar.fillMode = UIFillMode.Fill;
+            _progressBar.progressSprite = "ProgressBarFill";
+            _progressBar.isVisible = true;
+            _progressBar.minValue = 0f;
+            _progressBar.maxValue = 1f;
+            _progressBar.value = 0f;
+
+            _progressLabel = progressPanel.AddUIComponent<UILabel>();
+            _progressLabel.textScale = 0.8f;
+            _progressLabel.padding = new RectOffset(15, 10, 10, 15);
+            _progressLabel.relativePosition = new Vector2(0, 75);
+            _progressLabel.processMarkup = true;
+            _progressLabel.text = "Processing...";
+
+            _elapsedLabel = progressPanel.AddUIComponent<UILabel>();
+            _elapsedLabel.relativePosition = new Vector2(15, 105);
+            _elapsedLabel.text = "N/A";
+            _elapsedLabel.prefix = "Elapsed: ";
+            _elapsedLabel.Hide();
+            _stageLabel = progressPanel.AddUIComponent<UILabel>();
+            _stageLabel.relativePosition = new Vector2(PANEL_WIDTH - 110, 105);
+            _stageLabel.prefix = "Stage ";
+            _stageLabel.Hide();
+            _estimatedTimeLabel = progressPanel.AddUIComponent<UILabel>();
+            _estimatedTimeLabel.relativePosition = new Vector2(15, 125);
+            _estimatedTimeLabel.prefix = "ETA: ";
+            _estimatedTimeLabel.text = "";
+            _estimatedTimeLabel.Hide();
+        }
+
+        private void CloseButtonClick(UIComponent component, UIMouseEventParameter eventparam)
+        {
+            eventparam.Use();
+            OnClose(false);
+        }
+
+        private void OnClose(bool resetOnly = true)
+        {
+            Hide();
+            UIComponent modalComponent = UIView.GetModalComponent();
+            if (modalComponent == this)
+            {
+                UIView.PopModal();
+            }
+            if (!resetOnly)
+            {
+                Destroy(this.gameObject, 2);
+            }
+        }
+
+        public void ForceClose()
+        {
+            OnClose(false);
+        }
+
+        public void UpdateElapsedTime(TimeSpan elapsedTime)
+        {
+            if (elapsedTime > TimeSpan.Zero)
+            {
+                _elapsedLabel.text = $"{elapsedTime.Hours:D2}h:{elapsedTime.Minutes:D2}m:{elapsedTime.Seconds:D2}s";
+                _elapsedLabel.Show();
+            }
+            else
+            {
+                _elapsedLabel.Hide();
+                _elapsedLabel.text = string.Empty;
+            }
+        }
+
+        public void UpdateEstimatedTime(double estimatedMilliseconds)
+        {
+            if (estimatedMilliseconds == 0)
+            {
+                _estimatedTimeLabel.text = string.Empty;
+                _estimatedTimeLabel.Hide();
+            }
+            else
+            {
+                _estimatedTimeLabel.text = $"{DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30 * 1000):HH:mm}";
+                _estimatedTimeLabel.Show();
+            }
+        }
+
+        public void UpdateStage(int current, int of)
+        {
+            if (of == 0)
+            {
+                _stageLabel.Hide();
+            }
+            else
+            {
+                _stageLabel.Show();
+                _stageLabel.text = $"{current} of {of}";
+            }
+        }
+    }
+}

--- a/CompatibilityReport/UI/ProgressMonitorUI.cs
+++ b/CompatibilityReport/UI/ProgressMonitorUI.cs
@@ -189,6 +189,7 @@ namespace CompatibilityReport.UI
             _titleLabel = progressPanel.AddUIComponent<UILabel>();
             _titleLabel.padding = new RectOffset(15, 10, 5, 10);
             _titleLabel.relativePosition = new Vector2(0, 0);
+            _titleLabel.processMarkup = true;
             _titleLabel.text = string.Empty;
 
             _progressBar = progressPanel.AddUIComponent<UIProgressBar>();

--- a/CompatibilityReport/UI/SettingsUI.cs
+++ b/CompatibilityReport/UI/SettingsUI.cs
@@ -1,0 +1,399 @@
+﻿using System;
+using System.Diagnostics;
+using ColossalFramework.PlatformServices;
+using ColossalFramework.Plugins;
+using ColossalFramework.UI;
+using CompatibilityReport.Reporter;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Settings.ConfigData;
+using CompatibilityReport.Util;
+using ICities;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Debug = UnityEngine.Debug;
+using Logger = CompatibilityReport.Util.Logger;
+
+namespace CompatibilityReport.UI
+{
+    internal class SettingsUI
+    {
+        private static readonly string[] ReportTypes = new string[] { "text", "html", "text and html" };
+        private static readonly string[] DownloadOptions = new string[] { "Once a week", "Never (on-demand only) - not recommended!" };
+
+        private UIHelperBase settingsUIHelper;
+        private UIScrollablePanel optionsPanel;
+        private UITextField reportPathTextField;
+        private UILabel catalogVersionLabel;
+        
+        // make GlobalConfig Observable in the future?
+        private event Action<GlobalConfig> eventGlobalOptionsUpdated;
+
+        private static string ReportPathText => $"<color {ModSettings.SettingsUIColor}>{Toolkit.Privacy(GlobalConfig.Instance.GeneralConfig.ReportPath)}</color>";
+
+        private SettingsUI(UIHelperBase helper)
+        {
+            settingsUIHelper = helper;
+            optionsPanel = (helper as UIHelper).self as UIScrollablePanel;
+            optionsPanel.gameObject.AddComponent<GameObjectObserver>().eventGameObjectDestroyed += Dispose;
+            BuildUI();
+        }
+
+        internal static SettingsUI Create(UIHelperBase helper)
+        {
+            return new SettingsUI(helper);
+        }
+
+        private void Dispose()
+        {
+            Logger.Log("Disposing Settings UI", Logger.LogLevel.Debug);
+            eventGlobalOptionsUpdated = null;
+            reportPathTextField = null;
+            catalogVersionLabel = null;
+            settingsUIHelper = null;
+            optionsPanel = null;
+        }
+
+        private void BuildUI()
+        {
+            string scene = SceneManager.GetActiveScene().name;
+            Logger.Log($"OnSettingsUI called in scene {scene}.", Logger.Debug);
+
+            GlobalConfig config = GlobalConfig.Instance;
+
+            BuildRecordGroupUI(out bool canContinue);
+
+            if (!canContinue)
+            {
+                return;
+            }
+            
+            BuildCatalogOptionsUI();
+
+            BuildAdvancedOptionsUI();
+            
+            if (Toolkit.IsMainMenuScene(scene))
+            {
+                BuildUpdaterGroupUI();
+                
+                if (config.AdvancedConfig.ScanBeforeMainMenu)
+                {
+                    Report.Create(scene);
+                }
+            }
+            
+        }
+
+        private void BuildCatalogOptionsUI()
+        {
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            UIHelperBase catalogGroup = settingsUIHelper.AddGroup("Catalog options:");
+            UIPanel catalogPanel = (catalogGroup as UIHelper).self as UIPanel;
+            catalogVersionLabel = catalogPanel.AddUIComponent<UILabel>();
+            catalogVersionLabel.processMarkup = true;
+            catalogVersionLabel.text = $"Catalog version: {CatalogData.Catalog.SettingsUIText}";
+            catalogVersionLabel.textScale = 1.1f;
+            SettingsManager.eventCatalogUpdated += () => catalogVersionLabel.text = $"Catalog version: {CatalogData.Catalog.SettingsUIText}";
+            catalogGroup.AddSpace(10);
+
+            UIDropDown downloadFrequencyDropdown = catalogGroup.AddDropdown("Download: ", DownloadOptions, config.DownloadFrequency, SettingsManager.OnDownloadOptionChanged) as UIDropDown;
+            downloadFrequencyDropdown.width = 290f;
+            eventGlobalOptionsUpdated += c => downloadFrequencyDropdown.selectedIndex = c.GeneralConfig.DownloadFrequency;
+
+            UIComponent reportTypeContainer = downloadFrequencyDropdown.parent;
+            UIPanel downloadPanel = reportTypeContainer.AddUIComponent<UIPanel>();
+            downloadPanel.width = reportTypeContainer.width;
+            downloadPanel.height = downloadFrequencyDropdown.height;
+
+            UIButton download = catalogGroup.AddButton("Download now", SettingsManager.OnDownloadCatalog) as UIButton;
+            download.AlignTo(downloadPanel, UIAlignAnchor.TopLeft);
+            download.relativePosition += new UnityEngine.Vector3(downloadFrequencyDropdown.width + 30, -download.height);
+
+
+            var textWidthField = catalogGroup.AddTextfield("Text Report width", config.TextReportWidth.ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number) && number >= 30 && number <= 500)
+                {
+                    GeneralConfig c = GlobalConfig.Instance.GeneralConfig;
+                    if (c.TextReportWidth != number)
+                    {
+                        c.TextReportWidth = number;
+                        GlobalConfig.WriteConfig();
+                    }
+                } else { Logger.Log($"Incorrect Text Report width: {text}. Value should be between 30 and 500.");}
+            }) as UITextField;
+            textWidthField.submitOnFocusLost = false;
+            eventGlobalOptionsUpdated += c => textWidthField.text = c.GeneralConfig.TextReportWidth.ToString();
+        }
+
+        private void BuildAdvancedOptionsUI()
+        {
+            AdvancedConfig config = GlobalConfig.Instance.AdvancedConfig;
+            UIHelperBase advancedGroup = settingsUIHelper.AddGroup("Advanced options:");
+            UIPanel advGroupPanel = (advancedGroup as UIHelper).self as UIPanel;
+
+            UILabel modVersionLabel = advGroupPanel.AddUIComponent<UILabel>();
+            modVersionLabel.processMarkup = true;
+            modVersionLabel.text = $"Mod version: <color {ModSettings.SettingsUIColor}>{ModSettings.FullVersion}</color>";
+            modVersionLabel.textScale = 1.1f;
+
+            
+            // Todo 0.9 Activate checkboxes and button
+            // group.AddCheckbox("Show source URL in report", false, (bool _) => { });
+            // group.AddCheckbox("Show download date/time of mods in report", false, (bool _) => { });
+            // group.AddCheckbox("Debug logging", false, (bool _) => { });
+            advancedGroup.AddSpace(10);
+
+            var maxRetries = advancedGroup.AddTextfield("Number of catalog download retries", config.DownloadRetries.ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number) && number >=0 && number <= 10)
+                {
+                    AdvancedConfig advConfig = GlobalConfig.Instance.AdvancedConfig;
+                    if (advConfig.DownloadRetries != number)
+                    {
+                        advConfig.DownloadRetries = number;
+                        GlobalConfig.WriteConfig();
+                    }
+                } else { Logger.Log($"Incorrect Number of download retries: {text}. Value should be between 0 and 10.");}
+            }) as UITextField;
+            maxRetries.submitOnFocusLost = false;
+            maxRetries.eventTextCancelled += (component, value) => (component as UITextField).text = GlobalConfig.Instance.AdvancedConfig.DownloadRetries.ToString(); 
+            
+            var maxLogSize = advancedGroup.AddTextfield("Max log size (in kb)", (config.LogMaxSize / 1024).ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number) && number >= 10 && number <= 10000)
+                {
+                    AdvancedConfig advConfig = GlobalConfig.Instance.AdvancedConfig;
+                    int newSize = number * 1024;
+                    if (advConfig.LogMaxSize != newSize)
+                    {
+                        advConfig.LogMaxSize = newSize;
+                        GlobalConfig.WriteConfig();
+                    }
+                } else { Logger.Log($"Incorrect Max log size: {text}. Value should be between 10 and 10 000 (kb).");}
+            }) as UITextField;
+            maxLogSize.submitOnFocusLost = false;
+            maxLogSize.eventTextCancelled += (component, value) => (component as UITextField).text = (GlobalConfig.Instance.AdvancedConfig.LogMaxSize / 1024).ToString();
+            
+            var scanBeforeMenu = advancedGroup.AddCheckbox("Scan before entering Main Menu", config.ScanBeforeMainMenu, value => {
+                AdvancedConfig advConfig = GlobalConfig.Instance.AdvancedConfig;
+                if (advConfig.ScanBeforeMainMenu != value)
+                {
+                    advConfig.ScanBeforeMainMenu = value;
+                    GlobalConfig.WriteConfig();
+                }
+            }) as UICheckBox;
+            
+            var debugMode = advancedGroup.AddCheckbox("Debug Mode", config.DebugMode, value => {
+                AdvancedConfig advConfig = GlobalConfig.Instance.AdvancedConfig;
+                if (advConfig.DebugMode != value)
+                {
+                    advConfig.DebugMode = value;
+                    GlobalConfig.WriteConfig();
+                }
+            }) as UICheckBox;
+
+            eventGlobalOptionsUpdated += c => maxRetries.text = c.AdvancedConfig.DownloadRetries.ToString();
+            eventGlobalOptionsUpdated += c => maxLogSize.text = (c.AdvancedConfig.LogMaxSize / 1024).ToString();
+            eventGlobalOptionsUpdated += c => scanBeforeMenu.isChecked = c.AdvancedConfig.ScanBeforeMainMenu;
+            eventGlobalOptionsUpdated += c => debugMode.isChecked = c.AdvancedConfig.DebugMode;
+
+            // group.AddButton("Ignore selected incompatibilities", () => dummy++);
+
+            advancedGroup.AddButton("Reset all settings", () => {
+                SettingsManager.OnResetAllSettings();
+                eventGlobalOptionsUpdated?.Invoke(GlobalConfig.Instance);
+            });
+        }
+
+        private void BuildUpdaterGroupUI()
+        {
+            UpdaterConfig config = GlobalConfig.Instance.UpdaterConfig;
+            UIHelperBase updaterGroup = settingsUIHelper.AddGroup("Updater");
+
+            var steamMaxFailedPages = updaterGroup.AddTextfield("Steam max failed pages", config.SteamMaxFailedPages.ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number))
+                {
+                    UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+                    if (updaterConfig.SteamMaxFailedPages != number)
+                    {
+                        updaterConfig.SteamMaxFailedPages = number;
+                        GlobalConfig.WriteConfig();
+                    }
+                }
+            }) as UITextField;
+            steamMaxFailedPages.submitOnFocusLost = false;
+            steamMaxFailedPages.eventTextCancelled += (component, value) => (component as UITextField).text = GlobalConfig.Instance.UpdaterConfig.SteamMaxFailedPages.ToString();
+
+            var steamMaxListingPages = updaterGroup.AddTextfield("Steam max listing pages", config.SteamMaxListingPages.ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number))
+                {
+                    UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+                    if (updaterConfig.SteamMaxListingPages != number)
+                    {
+                        updaterConfig.SteamMaxListingPages = number;
+                        GlobalConfig.WriteConfig();
+                    }
+                }
+            }) as UITextField;
+            steamMaxListingPages.submitOnFocusLost = false;
+            steamMaxListingPages.eventTextCancelled += (component, value) => (component as UITextField).text = GlobalConfig.Instance.UpdaterConfig.SteamMaxListingPages.ToString();
+
+            var msPerModPage = updaterGroup.AddTextfield("Estimated milliseconds per mod page", config.EstimatedMillisecondsPerModPage.ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number))
+                {
+                    UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+                    if (updaterConfig.EstimatedMillisecondsPerModPage != number)
+                    {
+                        updaterConfig.EstimatedMillisecondsPerModPage = number;
+                        GlobalConfig.WriteConfig();
+                    }
+                }
+            }) as UITextField;
+            msPerModPage.submitOnFocusLost = false;
+            msPerModPage.eventTextCancelled += (component, value) => (component as UITextField).text = GlobalConfig.Instance.UpdaterConfig.EstimatedMillisecondsPerModPage.ToString();
+
+            var daysOfInactivity = updaterGroup.AddTextfield("Days of inactivity to retire author", config.DaysOfInactivityToRetireAuthor.ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number))
+                {
+                    UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+                    if (updaterConfig.DaysOfInactivityToRetireAuthor != number)
+                    {
+                        updaterConfig.DaysOfInactivityToRetireAuthor = number;
+                        GlobalConfig.WriteConfig();
+                    }
+                }
+            }) as UITextField;
+            daysOfInactivity.submitOnFocusLost = false;
+            daysOfInactivity.eventTextCancelled += (component, value) => (component as UITextField).text = GlobalConfig.Instance.UpdaterConfig.DaysOfInactivityToRetireAuthor.ToString();
+
+            var weeksForRetired = updaterGroup.AddTextfield("Weeks for soon retired", config.WeeksForSoonRetired.ToString(), _ => { }, text => {
+                if (TryGetNumber(text, out int number))
+                {
+                    UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+                    if (updaterConfig.WeeksForSoonRetired != number)
+                    {
+                        updaterConfig.WeeksForSoonRetired = number;
+                        GlobalConfig.WriteConfig();
+                    }
+                }
+            }) as UITextField;
+            weeksForRetired.submitOnFocusLost = false;
+            weeksForRetired.eventTextCancelled += (component, value) => (component as UITextField).text = GlobalConfig.Instance.UpdaterConfig.WeeksForSoonRetired.ToString();
+
+            UIPanel updaterPanel = HelperToUIPanel(updaterGroup);
+            UIPanel panel = updaterPanel.AddUIComponent<UIPanel>();
+            panel.relativePosition = Vector3.zero;
+            panel.width = 650;
+            panel.height = 40;
+            var helper = new UIHelper(panel);
+            helper.AddButton("Run Web Crawler", () => SettingsManager.OnStartWebCrawler(OpenProgressModal()));
+            helper.AddButton("Run Updater", () => SettingsManager.OnStartUpdater(OpenProgressModal()));
+            panel.autoLayoutDirection = LayoutDirection.Horizontal;
+            panel.autoLayoutPadding = new RectOffset(0, 10, 0, 0);
+            panel.autoLayout = true;
+            updaterGroup.AddButton("Run Road Asset Crawler (AN dependent)", () => SettingsManager.OnOneTimeAction(OpenProgressModal()));
+            
+            eventGlobalOptionsUpdated += (c) => steamMaxFailedPages.text = c.UpdaterConfig.SteamMaxFailedPages.ToString();
+            eventGlobalOptionsUpdated += (c) => steamMaxListingPages.text = c.UpdaterConfig.SteamMaxListingPages.ToString();
+            eventGlobalOptionsUpdated += (c) => msPerModPage.text = c.UpdaterConfig.EstimatedMillisecondsPerModPage.ToString();
+            eventGlobalOptionsUpdated += (c) => daysOfInactivity.text = c.UpdaterConfig.DaysOfInactivityToRetireAuthor.ToString();
+            eventGlobalOptionsUpdated += (c) => weeksForRetired.text = c.UpdaterConfig.WeeksForSoonRetired.ToString();
+        }
+
+        private bool TryGetNumber(string text, out int number)
+        {
+            return int.TryParse(text, out number);
+        }
+
+        private UIPanel HelperToUIPanel(UIHelperBase helperBase)
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            return (helperBase as UIHelper).self as UIPanel;
+        }
+
+        private ProgressMonitorUI OpenProgressModal()
+        {
+            ProgressMonitorUI ui = (ProgressMonitorUI)UIView.GetAView().AddUIComponent(typeof(ProgressMonitorUI));
+            ui.Initialize();
+            ui.Show();
+            ui.BringToFront();
+            UIView.PushModal(ui);
+            return ui;
+        }
+        
+        private void BuildRecordGroupUI(out bool shouldBuildOptions)
+        {
+            shouldBuildOptions = true;
+            if (PluginManager.noWorkshop || PlatformService.platformType != PlatformType.Steam)
+            {
+                UIPanel reportPanel = HelperToUIPanel(settingsUIHelper.AddGroup("Mod Errors"));
+                UILabel platformError = reportPanel.AddUIComponent<UILabel>();
+                platformError.text = PluginManager.noWorkshop 
+                    ? "'--noWorkshop' launch option detected. No report was generated" 
+                    : $"Platform not supported ({PlatformService.platformType})!\n" +
+                    "Access to the Steam Workshop is required for the mod to work properly.";
+                platformError.textColor = Color.red;
+                
+                // skip building the rest of options - won't be usable anyways 
+                shouldBuildOptions = false;
+                return;
+            }
+            
+            GeneralConfig config = GlobalConfig.Instance.GeneralConfig;
+            UIHelperBase reportGroup = settingsUIHelper.AddGroup("Report options:");
+
+            reportPathTextField = reportGroup.AddTextfield(
+                text: "Report path:",
+                defaultContent: config.ReportPath,
+                eventChangedCallback: _ => { },
+                eventSubmittedCallback: SettingsManager.OnChangeReportPath
+            ) as UITextField;
+            reportPathTextField.processMarkup = true;
+            reportPathTextField.width = 650f;
+            reportPathTextField.submitOnFocusLost = false;
+            reportPathTextField.eventTextCancelled += (component, value) => (component as UITextField).text = GlobalConfig.Instance.GeneralConfig.ReportPath;
+            eventGlobalOptionsUpdated += c => reportPathTextField.text = c.GeneralConfig.ReportPath;
+
+            reportGroup.AddSpace(5);
+
+            UIButton changePathBtn = reportGroup.AddButton("Change path", OnChangeReportPathClicked) as UIButton;
+            UIComponent pathContainer = changePathBtn.parent;
+            UIPanel pathPanel = pathContainer.AddUIComponent<UIPanel>();
+            pathPanel.width = pathContainer.width;
+            pathPanel.height = changePathBtn.height;
+            changePathBtn.AlignTo(pathPanel, UIAlignAnchor.TopLeft);
+
+            UIButton resetPathBtn = reportGroup.AddButton("Reset path to default", OnResetReportPathClicked) as UIButton;
+            resetPathBtn.AlignTo(pathPanel, UIAlignAnchor.TopLeft);
+            resetPathBtn.relativePosition += new UnityEngine.Vector3(changePathBtn.width + 10, 0);
+
+            reportGroup.AddSpace(20);
+
+            UIDropDown reportTypeDropdown = reportGroup.AddDropdown("Report type:", ReportTypes, config.ReportType, SettingsManager.OnReportTypeChange) as UIDropDown;
+            reportTypeDropdown.width = 180f;
+            eventGlobalOptionsUpdated += c => reportTypeDropdown.selectedIndex = c.GeneralConfig.ReportType;
+            UIComponent reportTypeContainer = reportTypeDropdown.parent;
+            UIPanel reportGenPanel = reportTypeContainer.AddUIComponent<UIPanel>();
+            reportGenPanel.width = reportTypeContainer.width;
+            reportGenPanel.height = reportTypeDropdown.height;
+
+            reportGroup.AddCheckbox("Use Steam Overlay to open html report if available", config.OpenHtmlReportInSteamOverlay, SettingsManager.OnOpenHtmlReportInSteamChanged);
+
+            UIButton openReportBtn = reportGroup.AddButton("Open report(s)", SettingsManager.OnOpenReports) as UIButton;
+
+            UIButton generateReportBtn = reportGroup.AddButton("Generate report(s)", SettingsManager.OnGenerateReports) as UIButton;
+            openReportBtn.AlignTo(reportGenPanel, UIAlignAnchor.TopLeft);
+            openReportBtn.relativePosition += new UnityEngine.Vector3(reportTypeDropdown.width + 30, -openReportBtn.height);
+            generateReportBtn.AlignTo(reportGenPanel, UIAlignAnchor.TopLeft);
+            generateReportBtn.relativePosition += new UnityEngine.Vector3(reportTypeDropdown.width + 30 + openReportBtn.width + 10, -openReportBtn.height);
+        }
+
+        private void OnResetReportPathClicked()
+        {
+            SettingsManager.OnResetReportPath();
+            reportPathTextField.text = ReportPathText;
+        }
+
+        private void OnChangeReportPathClicked()
+        {
+            SettingsManager.OnChangeReportPath(reportPathTextField.text);
+        }
+    }
+}

--- a/CompatibilityReport/UI/SettingsUI.cs
+++ b/CompatibilityReport/UI/SettingsUI.cs
@@ -47,10 +47,10 @@ namespace CompatibilityReport.UI
         {
             Logger.Log("Disposing Settings UI", Logger.LogLevel.Debug);
             eventGlobalOptionsUpdated = null;
-            reportPathTextField = null;
             catalogVersionLabel = null;
-            settingsUIHelper = null;
             optionsPanel = null;
+            reportPathTextField = null;
+            settingsUIHelper = null;
         }
 
         private void BuildUI()
@@ -73,8 +73,11 @@ namespace CompatibilityReport.UI
             
             if (Toolkit.IsMainMenuScene(scene))
             {
-                BuildUpdaterGroupUI();
-                
+                if (ModSettings.UpdaterAvailable)
+                {
+                    BuildUpdaterGroupUI();
+                }
+
                 if (config.AdvancedConfig.ScanBeforeMainMenu)
                 {
                     Report.Create(scene);
@@ -284,6 +287,7 @@ namespace CompatibilityReport.UI
             panel.height = 40;
             var helper = new UIHelper(panel);
             helper.AddButton("Run Web Crawler", () => SettingsManager.OnStartWebCrawler(OpenProgressModal()));
+            helper.AddButton("Run Web Crawler (quick)", () => SettingsManager.OnStartWebCrawler(OpenProgressModal(), quick: true));
             helper.AddButton("Run Updater", () => SettingsManager.OnStartUpdater(OpenProgressModal()));
             panel.autoLayoutDirection = LayoutDirection.Horizontal;
             panel.autoLayoutPadding = new RectOffset(0, 10, 0, 0);

--- a/CompatibilityReport/Updater/CatalogUpdater.cs
+++ b/CompatibilityReport/Updater/CatalogUpdater.cs
@@ -122,7 +122,7 @@ namespace CompatibilityReport.Updater
             progressMonitor.PushMessage("Loading Catalog...");
             yield return new WaitForSeconds(1);
             
-            Catalog catalog = Catalog.Load();
+            Catalog catalog = Catalog.Load(updaterRun: true);
 
             yield return new WaitForSeconds(0.5f);
             

--- a/CompatibilityReport/Updater/CatalogUpdater.cs
+++ b/CompatibilityReport/Updater/CatalogUpdater.cs
@@ -61,8 +61,8 @@ namespace CompatibilityReport.Updater
                 }
                 else
                 {
+                    // Save the new catalog.
                     UpdateAuthorRetirement(catalog);
-
                     UpdateCompatibilityModNames(catalog);
 
                     if (catalog.Version == 2 && catalog.Note == ModSettings.FirstCatalogNote)
@@ -91,6 +91,11 @@ namespace CompatibilityReport.Updater
             else
             {
                 DataDumper.Start(catalog);
+            }
+
+            if (ModSettings.UpdaterOneTimeActionEnabled)
+            {
+                OneTimeAction.Start();
             }
 
             Toolkit.DeleteFile(ModSettings.TempDownloadFullPath);

--- a/CompatibilityReport/Updater/DataDumper.cs
+++ b/CompatibilityReport/Updater/DataDumper.cs
@@ -120,7 +120,7 @@ namespace CompatibilityReport.Updater
 
             foreach (Mod catalogMod in catalog.Mods)
             {
-                if (catalogMod.Stability != Enums.Stability.IncompatibleAccordingToWorkshop && catalogMod.Stability != Enums.Stability.NotReviewed &&
+                if (catalogMod.SteamID > ModSettings.HighestFakeID && catalogMod.Stability != Enums.Stability.IncompatibleAccordingToWorkshop && catalogMod.Stability != Enums.Stability.NotReviewed &&
                     catalogMod.Updated < deadline && !catalogMod.Statuses.Contains(Enums.Status.Abandoned) && !catalogMod.Statuses.Contains(Enums.Status.Deprecated) &&
                     !catalogMod.Statuses.Contains(Enums.Status.Obsolete))
                 {

--- a/CompatibilityReport/Updater/DataDumper.cs
+++ b/CompatibilityReport/Updater/DataDumper.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using CompatibilityReport.CatalogData;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Settings.ConfigData;
 using CompatibilityReport.Util;
 
 namespace CompatibilityReport.Updater
@@ -41,7 +43,7 @@ namespace CompatibilityReport.Updater
             // Checks for needed review updates:
 
             // Authors that retire soon, to check them for activity in comments.
-            DumpAuthorsSoonRetired(catalog, DataDump, weeks: ModSettings.WeeksForSoonRetired);
+            DumpAuthorsSoonRetired(catalog, DataDump, weeks: GlobalConfig.Instance.UpdaterConfig.WeeksForSoonRetired);
 
             // Mods with a new update
             DumpModsWithNewUpdate(catalog, DataDump);
@@ -312,9 +314,10 @@ namespace CompatibilityReport.Updater
         {
             DataDump.AppendLine(Title($"Authors that will retire within { weeks } week{ (weeks > 1 ? "s" : "") }:"));
 
+            UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
             foreach (Author catalogAuthor in catalog.Authors)
             {
-                if (!catalogAuthor.Retired && catalogAuthor.LastSeen.AddDays(ModSettings.DaysOfInactivityToRetireAuthor - (weeks * 7)) < DateTime.Now)
+                if (!catalogAuthor.Retired && catalogAuthor.LastSeen.AddDays(updaterConfig.DaysOfInactivityToRetireAuthor - (weeks * 7)) < DateTime.Now)
                 {
                     DataDump.AppendLine($"{ catalogAuthor.Name } : { Toolkit.GetAuthorWorkshopUrl(catalogAuthor.SteamID, catalogAuthor.CustomUrl) }");
                 }

--- a/CompatibilityReport/Updater/OneTimeAction.cs
+++ b/CompatibilityReport/Updater/OneTimeAction.cs
@@ -1,9 +1,16 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Settings.ConfigData;
+using CompatibilityReport.UI;
 using CompatibilityReport.Util;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+using Logger = CompatibilityReport.Util.Logger;
 
 namespace CompatibilityReport.Updater
 {
@@ -23,6 +30,7 @@ namespace CompatibilityReport.Updater
 
 
         /// <summary>Starts the OneTimeAction. Downloads Steam webpages for all items and logs info to a file.</summary>
+        [Obsolete("Replaced to support reporting progress to UI")]
         public static void Start()
         {
             List<ulong> steamIDs = new List<ulong>();
@@ -37,7 +45,30 @@ namespace CompatibilityReport.Updater
             }
         }
 
+        /// <summary>Starts the OneTimeAction. Downloads Steam webpages for all items and logs info to a file.</summary>
+        public static IEnumerator Start(ProgressMonitor progressMonitor)
+        {
+            List<ulong> steamIDs = new List<ulong>();
 
+            progressMonitor.UpdateStage(1, 2);
+            yield return GetBasicInfo(steamIDs, progressMonitor);
+            
+            if (steamIDs.Count > 0) {
+                progressMonitor.UpdateStage(2, 2);
+                yield return GetDetails(steamIDs, progressMonitor);
+            }
+            else
+            {
+                progressMonitor.PushMessage("Did not found anything new.");
+                progressMonitor.UpdateStage(2, 2);
+            }
+            
+            progressMonitor.PushMessage("One-Time-Action complete.");
+            yield return new WaitForSeconds(2);
+            progressMonitor.Dispose();
+        }
+
+        [Obsolete("Replaced to support reporting progress to UI")]
         private static bool GetBasicInfo(List<ulong> steamIDs)
         {
             Logger.UpdaterLog("Updater started the one-time action. This may take quite some time.");
@@ -76,9 +107,62 @@ namespace CompatibilityReport.Updater
             return steamIDs.Count > 0;
         }
 
+        private static IEnumerator GetBasicInfo(List<ulong> steamIDs, ProgressMonitor progressMonitor)
+        {
+            Logger.UpdaterLog("Updater started the One-Time-Action. This may take quite some time.");
+
+            int pageNumber = 0;
+
+            Logger.UpdaterLog($"Downloading item listings from { steamUrl }");
+            progressMonitor.PushMessage("Started One-Time-Action");
+            progressMonitor.StartProgress(maxPages, $"Downloading item listing {maxPages} pages...");
+            progressMonitor.PushMessage($"Downloading item listing {maxPages} pages...");
+
+            // Download and read pages until we find no more items, or we reach a maximum number of pages, to avoid missing the mark and continuing for eternity.
+            while (pageNumber < maxPages)
+            {
+                progressMonitor.ReportProgress(pageNumber, $"Fetching page {pageNumber} of {maxPages}");
+                pageNumber++;
+                string url = $"{ steamUrl }&p={ pageNumber }";
+
+                KeyValuePair<bool, string> statusWithData = new KeyValuePair<bool, string>();
+                yield return Toolkit.DownloadPageText(url, result => statusWithData = result);
+                if (statusWithData.Key)
+                {
+                    if (!ReadItemListPageString(statusWithData.Value, steamIDs))
+                    {
+                        progressMonitor.Abort();
+                        pageNumber--; 
+                        break;
+                    }
+                }
+                else
+                {
+                    pageNumber--;
+
+                    Logger.UpdaterLog($"Download process interrupted due to a permanent error while downloading { url }", Logger.Error);
+                    progressMonitor.Abort();
+                    break;
+
+                }
+                yield return new WaitForSeconds(0.5f);
+            }
+
+            progressMonitor.PushMessage($"Finished downloading <color #00ff00>{pageNumber}</color> pages, found <color #00ff00>{steamIDs.Count}</color> items. Sorting...");
+            progressMonitor.ReportProgress(maxPages, $"Finished downloading {pageNumber} pages, found {steamIDs} items.");
+            
+            steamIDs.Sort();
+
+            Toolkit.DeleteFile(ModSettings.TempDownloadFullPath);
+
+            Logger.UpdaterLog($"Updater finished downloading { pageNumber } Steam Workshop 'item listing' pages and found { steamIDs.Count } items.");
+
+            yield return null;
+        }
 
         /// <summary>Extracts Steam IDs for all items from a downloaded item listing page and adds them to a list.</summary>
         /// <returns>True if items were found, false otherwise.</returns>
+        [Obsolete("Replaced to support reporting progress to UI")]
         private static bool ReadItemListingPage(List<ulong> steamIDs)
         {
             bool itemsFound = false;
@@ -109,14 +193,45 @@ namespace CompatibilityReport.Updater
 
             return itemsFound;
         }
+        
+        private static bool ReadItemListPageString(string pageString, List<ulong> steamIDs)
+        {
+            bool itemsFound = false;
+            string line;
+            string[] lines = pageString.Split('\n');
+            int linesCounter = 0;
+            while (linesCounter < lines.Length)
+            {
+                line = lines[linesCounter++];
+                // Search for the identifying string for the next item; continue with next line if not found.
+                if (!line.Contains(ModSettings.SearchModStart))
+                {
+                    continue;
+                }
+
+                ulong steamID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchSteamIDLeft, ModSettings.SearchSteamIDRight));
+
+                if (steamID == 0)
+                {
+                    Logger.UpdaterLog($"Steam ID not recognized on HTML line: { line }", Logger.Error);
+                    continue;
+                }
+
+                steamIDs.Add(steamID);
+                itemsFound = true;
+            }
+            return itemsFound;
+        }
 
 
         /// <summary>Downloads individual item pages from the Steam Workshop to get detailed item information for all items in the list.</summary>
+        [Obsolete("Replaced to support reporting progress to UI")]
         private static void GetDetails(List<ulong> steamIDs)
         {
             Stopwatch timer = Stopwatch.StartNew();
             int numberOfItems = steamIDs.Count;
-            long estimatedMilliseconds = ModSettings.EstimatedMillisecondsPerModPage * numberOfItems;
+            var config = GlobalConfig.Instance.UpdaterConfig;
+            long estimatedMilliseconds = config.EstimatedMillisecondsPerModPage * numberOfItems;
 
             Logger.UpdaterLog($"Updater started downloading { numberOfItems } individual Steam Workshop item pages. This should take about " +
                 $"{ Toolkit.TimeString(estimatedMilliseconds) } and should be ready around { DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30 * 1000):HH:mm}.");
@@ -130,6 +245,7 @@ namespace CompatibilityReport.Updater
             int itemsDownloaded = 0;
             int failedDownloads = 0;
 
+            int maxFailedPages = config.SteamMaxFailedPages;
             foreach (ulong steamID in steamIDs)
             {
                 if (!Toolkit.Download(Toolkit.GetWorkshopUrl(steamID), ModSettings.TempDownloadFullPath))
@@ -138,7 +254,7 @@ namespace CompatibilityReport.Updater
 
                     Logger.UpdaterLog($"Permanent error while downloading Steam Workshop page for { steamID }.", Logger.Error);
 
-                    if (failedDownloads <= ModSettings.SteamMaxFailedPages)
+                    if (failedDownloads <= maxFailedPages)
                     {
                         continue;
                     }
@@ -167,10 +283,83 @@ namespace CompatibilityReport.Updater
             Logger.UpdaterLog($"Updater finished downloading { itemsDownloaded } individual Steam Workshop item pages in " +
                 $"{ Toolkit.TimeString(timer.ElapsedMilliseconds, alwaysShowSeconds: true) }.");
         }
+        
+        /// <summary>Downloads individual item pages from the Steam Workshop to get detailed item information for all items in the list.</summary>
+        private static IEnumerator GetDetails(List<ulong> steamIDs, ProgressMonitor progressMonitor)
+        {
+            UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+            Stopwatch timer = Stopwatch.StartNew();
+            int numberOfItems = steamIDs.Count;
+            long estimatedMilliseconds = updaterConfig.EstimatedMillisecondsPerModPage * numberOfItems;
+
+            Logger.UpdaterLog($"Updater started downloading { numberOfItems } individual Steam Workshop item pages. This should take about " +
+                $"{ Toolkit.TimeString(estimatedMilliseconds) } and should be ready around { DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30 * 1000):HH:mm}.");
+
+            progressMonitor.PushMessage($"Updater started downloading { numberOfItems } individual Steam Workshop item pages");
+            progressMonitor.PushMessage($"This should take about { Toolkit.TimeString(estimatedMilliseconds) } and should be ready around { DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30 * 1000):HH:mm}.");
+            if (!Toolkit.SaveToFile($"{ title }", Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName)))
+            {
+                progressMonitor.PushMessage($"<color #ff0000>Could not write to file!</color>");
+                Logger.UpdaterLog($"Could not write to file \"{ Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName) }\".", Logger.Error);
+                yield break;
+            }
+
+            progressMonitor.StartProgress(steamIDs.Count, $"Fetching detail of {steamIDs.Count} items", true);
+            progressMonitor.PushMessage($"Fetching details of <color #00ffff>{ steamIDs.Count}</color> items...");
+            int itemsDownloaded = 0;
+            int failedDownloads = 0;
+            int idCount = steamIDs.Count;
+
+            foreach (ulong steamID in steamIDs)
+            {
+                progressMonitor.ReportProgress(itemsDownloaded, $"Downloading {itemsDownloaded}/{idCount}, {failedDownloads} failed");
+                KeyValuePair<bool, string> statusWithData = new KeyValuePair<bool, string>();
+                yield return Toolkit.DownloadPageText(Toolkit.GetWorkshopUrl(steamID), pair => statusWithData = pair);
+               
+                if (statusWithData.Key)
+                {
+                    if (!ReadItemPageString(statusWithData.Value, steamID))
+                    {
+                        Logger.UpdaterLog($"Item info not found for { steamID }.", Logger.Error);
+                    }
+                }
+                else
+                {
+                    if (failedDownloads++ <= updaterConfig.SteamMaxFailedPages)
+                    {
+                        progressMonitor.ReportProgress(itemsDownloaded + 1, $"Downloading {itemsDownloaded}/{idCount}, {failedDownloads} failed");
+                        continue;
+                    }
+                    else
+                    {
+                        progressMonitor.Abort();
+                        Logger.UpdaterLog("Download process stopped prematurely.", Logger.Error);
+                        yield break;
+                    }
+
+                }
+
+                itemsDownloaded++;
+
+                if (itemsDownloaded % 100 == 0)
+                {
+                    progressMonitor.PushMessage($" { itemsDownloaded }/{ numberOfItems } item pages downloaded.");
+                    Logger.UpdaterLog($"{ itemsDownloaded }/{ numberOfItems } item pages downloaded.");
+                }
+                
+                yield return null;
+            }
+
+            Logger.UpdaterLog($"Updater finished downloading { itemsDownloaded } individual Steam Workshop item pages in " +
+                $"{ Toolkit.TimeString(timer.ElapsedMilliseconds, alwaysShowSeconds: true) }.");
+            progressMonitor.ReportProgress(steamIDs.Count, $"Finished downloading { itemsDownloaded } pages in { Toolkit.TimeString(timer.ElapsedMilliseconds, alwaysShowSeconds: true) }.");
+            yield return new WaitForSeconds(1);
+        }
 
 
         /// <summary>Extracts detailed item information from a downloaded item page and logs the item if it matches the criteria.</summary>
         /// <returns>True if succesful, false if there was an error with the item page.</returns>
+        [Obsolete("Replaced to support reporting progress to UI")]
         public static bool ReadItemPage(ulong steamID)
         {
             bool steamIDmatched = false;
@@ -259,6 +448,116 @@ namespace CompatibilityReport.Updater
                         // Description is the last info we need from the page, so break out of the while loop.
                         break;
                     }
+                }
+            }
+
+            if (!steamIDmatched)
+            {
+                // We didn't find a Steam ID on the page, but no error page either. Must be a download issue or another Steam error.
+                Logger.UpdaterLog($"Can't find the Steam ID on downloaded page for { steamID }.", Logger.Warning);
+                return false;
+            }
+
+            return true;
+        }
+        
+        public static bool ReadItemPageString(string text, ulong steamID)
+        {
+            bool steamIDmatched = false;
+            string itemName = "";
+            string line;
+            int count = 0;
+            string[] lines = text.Split('\n');
+
+            while(count < lines.Length)
+            {
+                line = lines[count++];
+                if (!steamIDmatched)
+                {
+                    steamIDmatched = line.Contains($"{ ModSettings.SearchSteamID }{ steamID }");
+
+                    if (line.Contains(ModSettings.SearchItemNotFound))
+                    {
+                        Logger.UpdaterLog($"Can't read the Steam Workshop page for { steamID }.", Logger.Warning);
+                        return false;
+                    }
+
+                    // Keep reading lines until we find the Steam ID.
+                    continue;
+                }
+
+                // Item name.
+                if (line.Contains(ModSettings.SearchModNameLeft))
+                {
+                    itemName = Toolkit.CleanHtml(Toolkit.MidString(line, ModSettings.SearchModNameLeft, ModSettings.SearchModNameRight));
+
+                    if (string.IsNullOrEmpty(itemName))
+                    {
+                        // An empty item name might be an error, although there is at least one Steam Workshop item without a name (ofcourse there is).
+                        Logger.UpdaterLog($"Item name not found for { steamID }. This could be an actual unnamed item, or a Steam error.", Logger.Warning);
+                    }
+                }
+
+                // Required mods and assets. The search string is a container with all required items on the next lines.
+                else if (line.Contains(ModSettings.SearchRequiredMod))
+                {
+                    // Get all required items from the next lines, until we find no more. Max. 50 times to avoid an infinite loop.
+                    for (var i = 1; i <= 50; i++)
+                    {
+                        if (++count + i > lines.Length - 1)
+                        {
+                            break;
+                        }
+                        line = lines[count];
+                        ulong requiredID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchRequiredModLeft, ModSettings.SearchRequiredModRight));
+
+                        if (requiredID == 0)
+                        {
+                            break;
+                        }
+                        
+                        if (requiredID == requiredItem1 || requiredID == requiredItem2)
+                        {
+                            Toolkit.SaveToFile($"{ itemName }, { Toolkit.GetWorkshopUrl(steamID) }\n", 
+                                Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName), append: true);
+                            return true;
+                        }
+                        if (count + 3 > lines.Length - 1)
+                        {
+                            break;
+                        }
+                        count += 3;
+                    }
+                }
+
+                // Description.
+                else if (line.Contains(ModSettings.SearchDescription))
+                {
+                    // Usually, the complete description is on one line. However, it might be split when using certain bbcode. Combine up to 30 lines.
+                    for (var i = 1; i <= 30; i++)
+                    {
+                        if (++count + i > lines.Length - 1)
+                        {
+                            break;
+                        }
+                        line = lines[count];
+
+                        // Break out of the for loop when a line is found that marks the end of the description.
+                        if (line == ModSettings.SearchDescriptionNextLine || line == ModSettings.SearchDescriptionNextSection)
+                        {
+                            break;
+                        }
+
+                        if (line.Contains(descriptionString1) || line.Contains(descriptionString2))
+                        {
+                            Toolkit.SaveToFile($"[MAYBE] { itemName }, { Toolkit.GetWorkshopUrl(steamID) }\n", 
+                                Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName), append: true);
+                            return true;
+                        }
+                    }
+
+                    // Description is the last info we need from the page, so break out of the while loop.
+                    break;
                 }
             }
 

--- a/CompatibilityReport/Updater/OneTimeAction.cs
+++ b/CompatibilityReport/Updater/OneTimeAction.cs
@@ -1,0 +1,275 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using CompatibilityReport.Util;
+
+namespace CompatibilityReport.Updater
+{
+    /// <summary>OneTimeAction gathers information from the Steam Workshop pages for specific items and logs those to a file.</summary>
+    /// <remarks>This process can take a long time, depending on the number of items; roughly half a second per item.</remarks>
+    public static class OneTimeAction
+    {
+        // These constants define which info is being gathered.
+        private const string title = "Roads that require the Adaptive Networks mod.\n=============================================\n" +
+            "([MAYBE] means the description mentions the mod, but the mod is not set as required)\n\n";
+        private const string steamUrl = "https://steamcommunity.com/workshop/browse/?appid=255710&browsesort=mostrecent&requiredtags[]=Road";
+        private const int maxPages = 200;
+        private const ulong requiredItem1 = 2414618415;     // Adaptive Networks stable
+        private const ulong requiredItem2 = 2669938594;     // Adaptive Networks alpha
+        private const string descriptionString1 = "Adaptive Networks";
+        private const string descriptionString2 = "Adaptive Roads";
+
+
+        /// <summary>Starts the OneTimeAction. Downloads Steam webpages for all items and logs info to a file.</summary>
+        public static void Start()
+        {
+            List<ulong> steamIDs = new List<ulong>();
+
+            if (GetBasicInfo(steamIDs))
+            {
+                GetDetails(steamIDs);
+
+                // Todo 0.8 This can be removed after updater settings are implemented. Make disable-after-run an option in the settings file.
+                Toolkit.MoveFile(Path.Combine(ModSettings.UpdaterPath, $"{ ModSettings.InternalName }_OneTimeAction.enabled"),
+                    Path.Combine(ModSettings.UpdaterPath, $"{ ModSettings.InternalName }_OneTimeAction.disabled"));
+            }
+        }
+
+
+        private static bool GetBasicInfo(List<ulong> steamIDs)
+        {
+            Logger.UpdaterLog("Updater started the one-time action. This may take quite some time.");
+
+            int pageNumber = 0;
+
+            Logger.UpdaterLog($"Downloading item listings from { steamUrl }");
+
+            // Download and read pages until we find no more items, or we reach a maximum number of pages, to avoid missing the mark and continuing for eternity.
+            while (pageNumber < maxPages)
+            {
+                pageNumber++;
+                string url = $"{ steamUrl }&p={ pageNumber }";
+
+                if (!Toolkit.Download(url, ModSettings.TempDownloadFullPath))
+                {
+                    pageNumber--;
+
+                    Logger.UpdaterLog($"Download process interrupted due to a permanent error while downloading { url }", Logger.Error);
+                    break;
+                }
+
+                if (!ReadItemListingPage(steamIDs))
+                {
+                    pageNumber--;
+                    break;
+                }
+            }
+
+            steamIDs.Sort();
+
+            Toolkit.DeleteFile(ModSettings.TempDownloadFullPath);
+
+            Logger.UpdaterLog($"Updater finished downloading { pageNumber } Steam Workshop 'item listing' pages and found { steamIDs.Count } items.");
+
+            return steamIDs.Count > 0;
+        }
+
+
+        /// <summary>Extracts Steam IDs for all items from a downloaded item listing page and adds them to a list.</summary>
+        /// <returns>True if items were found, false otherwise.</returns>
+        private static bool ReadItemListingPage(List<ulong> steamIDs)
+        {
+            bool itemsFound = false;
+            string line;
+
+            using (StreamReader reader = File.OpenText(ModSettings.TempDownloadFullPath))
+            {
+                while ((line = reader.ReadLine()) != null)
+                {
+                    // Search for the identifying string for the next item; continue with next line if not found.
+                    if (!line.Contains(ModSettings.SearchModStart))
+                    {
+                        continue;
+                    }
+
+                    ulong steamID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchSteamIDLeft, ModSettings.SearchSteamIDRight));
+
+                    if (steamID == 0)
+                    {
+                        Logger.UpdaterLog($"Steam ID not recognized on HTML line: { line }", Logger.Error);
+                        continue;
+                    }
+
+                    steamIDs.Add(steamID);
+                    itemsFound = true;
+                }
+            }
+
+            return itemsFound;
+        }
+
+
+        /// <summary>Downloads individual item pages from the Steam Workshop to get detailed item information for all items in the list.</summary>
+        private static void GetDetails(List<ulong> steamIDs)
+        {
+            Stopwatch timer = Stopwatch.StartNew();
+            int numberOfItems = steamIDs.Count;
+            long estimatedMilliseconds = ModSettings.EstimatedMillisecondsPerModPage * numberOfItems;
+
+            Logger.UpdaterLog($"Updater started downloading { numberOfItems } individual Steam Workshop item pages. This should take about " +
+                $"{ Toolkit.TimeString(estimatedMilliseconds) } and should be ready around { DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30 * 1000):HH:mm}.");
+
+            if (!Toolkit.SaveToFile($"{ title }", Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName)))
+            {
+                Logger.UpdaterLog($"Could not write to file \"{ Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName) }\".", Logger.Error);
+                return;
+            }
+
+            int itemsDownloaded = 0;
+            int failedDownloads = 0;
+
+            foreach (ulong steamID in steamIDs)
+            {
+                if (!Toolkit.Download(Toolkit.GetWorkshopUrl(steamID), ModSettings.TempDownloadFullPath))
+                {
+                    failedDownloads++;
+
+                    Logger.UpdaterLog($"Permanent error while downloading Steam Workshop page for { steamID }.", Logger.Error);
+
+                    if (failedDownloads <= ModSettings.SteamMaxFailedPages)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        Logger.UpdaterLog("Download process stopped prematurely.", Logger.Error);
+                        break;
+                    }
+                }
+
+                itemsDownloaded++;
+
+                if (itemsDownloaded % 100 == 0)
+                {
+                    Logger.UpdaterLog($"{ itemsDownloaded }/{ numberOfItems } item pages downloaded.");
+                }
+
+                if (!ReadItemPage(steamID))
+                {
+                    Logger.UpdaterLog($"Item info not found for { steamID }.", Logger.Error);
+                }
+            }
+
+            Toolkit.DeleteFile(ModSettings.TempDownloadFullPath);
+
+            Logger.UpdaterLog($"Updater finished downloading { itemsDownloaded } individual Steam Workshop item pages in " +
+                $"{ Toolkit.TimeString(timer.ElapsedMilliseconds, alwaysShowSeconds: true) }.");
+        }
+
+
+        /// <summary>Extracts detailed item information from a downloaded item page and logs the item if it matches the criteria.</summary>
+        /// <returns>True if succesful, false if there was an error with the item page.</returns>
+        public static bool ReadItemPage(ulong steamID)
+        {
+            bool steamIDmatched = false;
+            string itemName = "";
+            string line;
+
+            using (StreamReader reader = File.OpenText(ModSettings.TempDownloadFullPath))
+            {
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (!steamIDmatched)
+                    {
+                        steamIDmatched = line.Contains($"{ ModSettings.SearchSteamID }{ steamID }");
+
+                        if (line.Contains(ModSettings.SearchItemNotFound))
+                        {
+                            Logger.UpdaterLog($"Can't read the Steam Workshop page for { steamID }.", Logger.Warning);
+                            return false;
+                        }
+
+                        // Keep reading lines until we find the Steam ID.
+                        continue;
+                    }
+
+                    // Item name.
+                    if (line.Contains(ModSettings.SearchModNameLeft))
+                    {
+                        itemName = Toolkit.CleanHtml(Toolkit.MidString(line, ModSettings.SearchModNameLeft, ModSettings.SearchModNameRight));
+
+                        if (string.IsNullOrEmpty(itemName))
+                        {
+                            // An empty item name might be an error, although there is at least one Steam Workshop item without a name (ofcourse there is).
+                            Logger.UpdaterLog($"Item name not found for { steamID }. This could be an actual unnamed item, or a Steam error.", Logger.Warning);
+                        }
+                    }
+
+                    // Required mods and assets. The search string is a container with all required items on the next lines.
+                    else if (line.Contains(ModSettings.SearchRequiredMod))
+                    {
+                        // Get all required items from the next lines, until we find no more. Max. 50 times to avoid an infinite loop.
+                        for (var i = 1; i <= 50; i++)
+                        {
+                            line = reader.ReadLine();
+                            ulong requiredID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchRequiredModLeft, ModSettings.SearchRequiredModRight));
+
+                            if (requiredID == 0)
+                            {
+                                break;
+                            }
+                            
+                            if (requiredID == requiredItem1 || requiredID == requiredItem2)
+                            {
+                                Toolkit.SaveToFile($"{ itemName }, { Toolkit.GetWorkshopUrl(steamID) }\n", 
+                                    Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName), append: true);
+                                return true;
+                            }
+
+                            line = reader.ReadLine();
+                            line = reader.ReadLine();
+                            line = reader.ReadLine();
+                        }
+                    }
+
+                    // Description.
+                    else if (line.Contains(ModSettings.SearchDescription))
+                    {
+                        // Usually, the complete description is on one line. However, it might be split when using certain bbcode. Combine up to 30 lines.
+                        for (var i = 1; i <= 30; i++)
+                        {
+                            line = reader.ReadLine();
+
+                            // Break out of the for loop when a line is found that marks the end of the description.
+                            if (line == ModSettings.SearchDescriptionNextLine || line == ModSettings.SearchDescriptionNextSection)
+                            {
+                                break;
+                            }
+
+                            if (line.Contains(descriptionString1) || line.Contains(descriptionString2))
+                            {
+                                Toolkit.SaveToFile($"[MAYBE] { itemName }, { Toolkit.GetWorkshopUrl(steamID) }\n", 
+                                    Path.Combine(ModSettings.UpdaterPath, ModSettings.OneTimeActionFileName), append: true);
+                                return true;
+                            }
+                        }
+
+                        // Description is the last info we need from the page, so break out of the while loop.
+                        break;
+                    }
+                }
+            }
+
+            if (!steamIDmatched)
+            {
+                // We didn't find a Steam ID on the page, but no error page either. Must be a download issue or another Steam error.
+                Logger.UpdaterLog($"Can't find the Steam ID on downloaded page for { steamID }.", Logger.Warning);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/CompatibilityReport/Updater/Updater Guide.md
+++ b/CompatibilityReport/Updater/Updater Guide.md
@@ -1,6 +1,6 @@
 # Compatibility Report - Updater Guide
 
-The Updater only runs when an Updater folder exists, so it won't run for regular users. The Updater has two parts. The WebCrawler crawls the Steam Workshop for mod information, including mod name, author, published/update dates, required DLC/mods, source URL, compatible game version and several statuses: unlisted/removed from Workshop, incompatible, author retirement, no description. The FileImporter imports data from CSV files, including information that cannot be found by an automated process, like compatibility and suggested successor/alternative mods. It also allows the creation of groups for required and recommended mods. The updater creates a new catalog that can be uploaded to the download location, so all mod users get this new catalog on the next game start. If you think about enabling the updater for yourself, mind that the WebCrawler downloads nearly 2000 webpages and takes about 15 minutes on a fast computer with decent internet connection.
+The Updater only runs when a "CompatibilityReportUpdater" folder exists in the games local AppData folder, so it won't run for regular users. The updater has two parts. The **WebCrawler** crawls the Steam Workshop for mod information, including mod name, author, published/update dates, required DLC/mods, source URL, compatible game version and several statuses: unlisted/removed from Workshop, incompatible, author retirement, no description. The **FileImporter** imports data from CSV files, including information that cannot be found by an automated process, like compatibility and suggested successor/alternative mods. It also allows the creation of groups for required and recommended mods. The updater creates a new catalog that can be uploaded to the download location, so all mod users get this new catalog on the next game start. If you think about enabling the updater for yourself, mind that the WebCrawler downloads more than 2000 webpages and takes about 15 minutes on a fast computer with decent internet connection. To avoid unnecessary downloads, the WebCrawler only runs if a file called "CompatibilityReport_WebCrawler.enabled" exists inside the Updater folder. The updater also creates a DataDump file with various checks and relevant information for updating, and can run a OneTimeAction (disabled by default).
 
 The FileImporter gathers its information from CSV files. These should be placed in the updater folder where the new catalogs are written as well. Update actions can be bundled in one CSV file or split into multiple files. Multiple files will be read in alphabetical order. Filenames don't matter, but should end in .csv. After updating, the processed CSV files are renamed to .txt to avoid duplicate additions to the catalog on a next updater run.
 
@@ -68,7 +68,7 @@ Parameters in square brackets are optional. The symbol :zap: means an exclusion 
 * Remove_AuthorUrl, \<author ID\>
 * Remove_Retired, \<author ID | custom url\> *(only works if added manually before)*
 
-### Available catalog actions
+### Catalog actions
 * Set_CatalogGameVersion, \<game version string\>
 * Set_CatalogNote, \<text\>
 * Set_CatalogHeaderText, \<text\>
@@ -77,7 +77,7 @@ Parameters in square brackets are optional. The symbol :zap: means an exclusion 
 * Remove_CatalogHeaderText
 * Remove_CatalogFooterText
 
-### Available miscellaneous actions
+### Miscellaneous actions
 * Add_RequiredAssets, \<asset ID\> [, \<asset ID\>, ...]
   * *Only needed to differentiate between a required asset and a required mod that isn't in the catalog.*
 * Remove_RequiredAssets, \<asset ID\> [, \<asset ID\>, ...]

--- a/CompatibilityReport/Updater/WebCrawler.cs
+++ b/CompatibilityReport/Updater/WebCrawler.cs
@@ -1,10 +1,16 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using CompatibilityReport.CatalogData;
+using CompatibilityReport.Settings;
+using CompatibilityReport.Settings.ConfigData;
+using CompatibilityReport.UI;
 using CompatibilityReport.Util;
+using UnityEngine;
+using Logger = CompatibilityReport.Util.Logger;
 
 namespace CompatibilityReport.Updater
 {
@@ -15,7 +21,9 @@ namespace CompatibilityReport.Updater
     /// <item>Author: name, Steam ID or Custom URL, last seen date (based on mod updates, not on comments), retired status (based on last seen date)</item></list></remarks>
     public static class WebCrawler
     {
+        
         /// <summary>Starts the WebCrawler. Downloads Steam webpages for all mods and update the catalog with found information.</summary>
+        [Obsolete("Replaced to support reporting progress to UI")]
         public static void Start(Catalog catalog)
         {
             CatalogUpdater.SetReviewDate(DateTime.Now);
@@ -25,16 +33,51 @@ namespace CompatibilityReport.Updater
                 GetDetails(catalog);
 
                 GetMapThemes(catalog);
-
-                // Todo 0.8 This can be removed after updater settings are implemented. Make disable-after-run an option in the settings file.
-                Toolkit.MoveFile(Path.Combine(ModSettings.UpdaterPath, $"{ ModSettings.InternalName }_WebCrawler.enabled"), 
-                    Path.Combine(ModSettings.UpdaterPath, $"{ ModSettings.InternalName }_WebCrawler.disabled"));
             }
+        }
+        
+        /// <summary>Starts the WebCrawler, reports progress. Downloads Steam webpages for all mods and update the catalog with found information.</summary>
+        public static IEnumerator StartWithProgress(Catalog catalog, ProgressMonitor progressMonitor)
+        {
+            CatalogUpdater.SetReviewDate(DateTime.Now);
+
+            progressMonitor.PushMessage("Web Crawler processing Catalog...");
+            bool shouldContinue = false;
+            yield return GetBasicInfoWithProgress(catalog, progressMonitor, result => shouldContinue = result);
+            
+            if (shouldContinue)
+            {
+                progressMonitor.PushMessage("Web Crawler fetching mod details...");
+                yield return GetDetailsWithProgress(catalog, progressMonitor);
+
+                progressMonitor.PushMessage("Web Crawler fetching map themes...");
+                yield return GetMapThemesWithProgress(catalog, progressMonitor);
+            }
+
+            progressMonitor.UpdateStage(7, 8);
+            progressMonitor.PushMessage("Web Crawler finished.");
+            yield return new WaitForSeconds(1);
+            progressMonitor.UpdateStage(8, 8);
+            progressMonitor.PushMessage("Data dumper started...");
+            
+            DataDumper.Start(catalog);
+            
+            progressMonitor.PushMessage("Data dumper finished.");
+            yield return new WaitForSeconds(1);
+            progressMonitor.PushMessage("Catalog dumper started...");
+
+            string dumpPath = Path.Combine(ModSettings.UpdaterPath, ModSettings.CatalogDumpFileName);
+            bool dumpSuccess = catalog.Save(dumpPath);
+            progressMonitor.PushMessage($"Catalog dumper finished. {(dumpSuccess ? "<color #00ff00>Sucess</color>" : "<color #ff0000>Failure</color>")}!\n See: {dumpPath}");
+            
+            yield return new WaitForSeconds(3);
+            progressMonitor.Dispose();
         }
 
 
         /// <summary>Downloads 'mod listing' pages from the Steam Workshop to get mod names and IDs for all available mods.</summary>
         /// <returns>True if at least one mod was found, false otherwise.</returns>
+        [Obsolete("Replaced to support reporting progress to UI")]
         private static bool GetBasicInfo(Catalog catalog)
         {
             Logger.UpdaterLog("Updater started downloading Steam Workshop 'mod listing' pages. This should take less than 1 minute.");
@@ -42,6 +85,7 @@ namespace CompatibilityReport.Updater
             int totalMods = 0;
             int totalPages = 0;
             
+            UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
             // Go through the different mod listings: mods and camera scripts, both regular and incompatible.
             foreach (string steamUrl in ModSettings.SteamModListingUrls)
             {
@@ -50,7 +94,7 @@ namespace CompatibilityReport.Updater
                 int pageNumber = 0;
 
                 // Download and read pages until we find no more mods, or we reach a maximum number of pages, to avoid missing the mark and continuing for eternity.
-                while (pageNumber < ModSettings.SteamMaxListingPages)
+                while (pageNumber < updaterConfig.SteamMaxListingPages)
                 {
                     pageNumber++;
                     string url = $"{ steamUrl }&p={ pageNumber }";
@@ -87,15 +131,92 @@ namespace CompatibilityReport.Updater
             Toolkit.DeleteFile(ModSettings.TempDownloadFullPath);
 
             // Note: about 75% of the total time is downloading, the other 25% is processing.
-            Logger.UpdaterLog($"Updater finished downloading { totalPages } Steam Workshop 'mod listing' pages and found { totalMods } mods.");
+            Logger.UpdaterLog($"Updater finished downloading { totalPages } Steam Workshop 'mod listing' pages\nfound { totalMods } mods.");
 
             return totalMods > 0;
+        }
+
+        /// <summary>Downloads 'mod listing' pages from the Steam Workshop to get mod names and IDs for all available mods.</summary>
+        /// <returns>Enumerator, invokes onCompleted(bool) with status True if at least one mod was found, false otherwise.</returns>
+        private static IEnumerator GetBasicInfoWithProgress(Catalog catalog, ProgressMonitor monitor, Action<bool> onCompleted)
+        {
+            Logger.UpdaterLog("Updater started downloading Steam Workshop 'mod listing' pages. This should take less than 1 minute.");
+
+            int totalMods = 0;
+            int totalPages = 0;
+            UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+            int maxListingPages = updaterConfig.SteamMaxListingPages;
+            int index = 0;
+            // Go through the different mod listings: mods and camera scripts, both regular and incompatible.
+            foreach (string steamUrl in ModSettings.SteamModListingUrls)
+            {
+                monitor.UpdateStage(1 + index++, 8);
+                Logger.UpdaterLog($"Starting downloads from { steamUrl }");
+                
+                int pageNumber = 0;
+                monitor.StartProgress(maxListingPages, $"Starting downloads from url: { steamUrl.Split(new string[] {"requiredtags"}, StringSplitOptions.None)[1].Substring(2) }", true);
+                monitor.PushMessage($"Starting downloads from url: <color #FFFF00>{ steamUrl.Split(new string[] {"requiredtags"}, StringSplitOptions.None)[1].Substring(2) }</color>");
+                // Download and read pages until we find no more mods, or we reach a maximum number of pages, to avoid missing the mark and continuing for eternity.
+                while (pageNumber < maxListingPages)
+                {
+                    pageNumber++;
+                    string url = $"{ steamUrl }&p={ pageNumber }";
+
+                    KeyValuePair<bool, string> statusWithText = new KeyValuePair<bool, string>();
+                    yield return Toolkit.DownloadPageText(url, result => statusWithText = result);
+
+                    monitor.ReportProgress(pageNumber, $"Downloading <color #00ff00>{pageNumber}</color> of <color #16a085>{maxListingPages}</color>");
+                    if (!statusWithText.Key)
+                    {
+                        pageNumber--;
+
+                        monitor.PushMessage($"<color #ff0000>Download process interrupted due to a permanent error while downloading</color>\n { url }");
+                        Logger.UpdaterLog($"Download process interrupted due to a permanent error while downloading { url }", Logger.Error);
+                        monitor.Abort();
+                        break;
+                    }
+
+                    int modsFoundThisPage = ReadModListingTextPage(catalog, statusWithText.Value, incompatibleMods: steamUrl.Contains("incompatible"));
+                        //ReadModListingPage(catalog, incompatibleMods: steamUrl.Contains("incompatible"));
+
+                    if (modsFoundThisPage == 0)
+                    {
+                        pageNumber--;
+
+                        if (pageNumber == 0)
+                        {
+                            Logger.UpdaterLog("Found no mods on page 1.");
+                        }
+
+                        // todo fix: it may break before reaching maxListingPage if no mods on page.
+                        break;
+                    }
+
+                    totalMods += modsFoundThisPage;
+                    monitor.PushMessage($"Found <color #00ff00>{modsFoundThisPage}</color>, total: <color #16a085>{totalMods}</color>");
+                    Logger.UpdaterLog($"Found { modsFoundThisPage } mods on page { pageNumber }.");
+                }
+
+                totalPages += pageNumber;
+            }
+
+            // Toolkit.DeleteFile(ModSettings.TempDownloadFullPath);
+
+            // Note: about 75% of the total time is downloading, the other 25% is processing.
+            Logger.UpdaterLog($"Updater finished downloading { totalPages } Steam Workshop 'mod listing' pages and found { totalMods } mods.");
+            
+            monitor.ReportProgress(maxListingPages, $"Updater finished downloading <color #00ff00>{ totalPages }</color>, found: <color #00ff00>{totalMods}</color> mods");
+            monitor.PushMessage($"Updater finished downloading <color #00ff00>{ totalPages }</color> 'mod listing' pages, found: <color #00ff00>{totalMods}</color> mods.");
+            
+            yield return new WaitForSeconds(2);
+            onCompleted(totalMods > 0);
         }
 
 
         /// <summary>Extracts Steam IDs and mod names for all mods from a downloaded mod listing page and adds/updates this in the catalog.</summary>
         /// <remarks>Sets the auto review date, (re)sets 'incompatible according to workshop' stability and removes unlisted and 'removed from workshop' statuses.</remarks>
         /// <returns>The number of mods found on this page.</returns>
+        [Obsolete("Replaced to support reporting progress to UI")]
         private static int ReadModListingPage(Catalog catalog, bool incompatibleMods)
         {
             int modsFoundThisPage = 0;
@@ -153,9 +274,70 @@ namespace CompatibilityReport.Updater
             return modsFoundThisPage;
         }
 
+        /// <summary>Extracts Steam IDs and mod names for all mods from a downloaded mod listing page and adds/updates this in the catalog.</summary>
+        /// <remarks>Sets the auto review date, (re)sets 'incompatible according to workshop' stability and removes unlisted and 'removed from workshop' statuses.</remarks>
+        /// <returns>The number of mods found on this page.</returns>
+        private static int ReadModListingTextPage(Catalog catalog, string page, bool incompatibleMods)
+        {
+            int modsFoundThisPage = 0;
+            string line;
+            int index = 0;
+            string[] lines = page.Split('\n');
+
+            while (index < lines.Length)
+            {
+                line = lines[index++];
+                // Search for the identifying string for the next mod; continue with next line if not found.
+                if (!line.Contains(ModSettings.SearchModStart))
+                {
+                    continue;
+                }
+
+                ulong steamID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchSteamIDLeft, ModSettings.SearchSteamIDRight));
+
+                if (steamID == 0) 
+                {
+                    Logger.UpdaterLog($"Steam ID not recognized on HTML line: { line }", Logger.Error);
+                    continue;
+                }
+
+                modsFoundThisPage++;
+
+                string modName = Toolkit.CleanHtml(Toolkit.MidString(line, ModSettings.SearchListingModNameLeft, ModSettings.SearchListingModNameRight));
+
+                if (string.IsNullOrEmpty(modName) && !catalog.SuppressedWarnings.Contains(steamID))
+                {
+                    // An empty mod name might be an error, although there is a Steam Workshop mod without a name (ofcourse there is).
+                    Logger.UpdaterLog($"Mod name not found for { steamID }. This could be an actual unnamed mod, or a Steam error.", Logger.Warning);
+                }
+
+                Mod catalogMod = catalog.GetMod(steamID) ?? CatalogUpdater.AddMod(catalog, steamID, modName, incompatibleMods);
+
+                CatalogUpdater.RemoveStatus(catalog, catalogMod, Enums.Status.RemovedFromWorkshop);
+                CatalogUpdater.RemoveStatus(catalog, catalogMod, Enums.Status.UnlistedInWorkshop);
+
+                if (incompatibleMods && catalogMod.Stability != Enums.Stability.IncompatibleAccordingToWorkshop)
+                {
+                    CatalogUpdater.UpdateMod(catalog, catalogMod, stability: Enums.Stability.IncompatibleAccordingToWorkshop, stabilityNote: "");
+                }
+                else if (!incompatibleMods && catalogMod.Stability == Enums.Stability.IncompatibleAccordingToWorkshop)
+                {
+                    CatalogUpdater.UpdateMod(catalog, catalogMod, stability: Enums.Stability.NotReviewed, stabilityNote: "");
+                }
+
+                // Update the name and the auto review date.
+                CatalogUpdater.UpdateMod(catalog, catalogMod, modName);
+
+                // Author info can be found on the next line, but skip it here and get it later on the mod page.
+            }
+
+            return modsFoundThisPage;
+        }
+
 
         /// <summary>Downloads 'Map Theme listing' pages from the Steam Workshop to get Steam IDs for all available map themes.</summary>
         /// <remarks>The Steam IDs will be added to the list of Map Themes.</remarks>
+        [Obsolete("Replaced to support reporting progress to UI")]
         private static void GetMapThemes(Catalog catalog)
         {
             Logger.UpdaterLog("Updater started downloading Steam Workshop 'map theme listing' pages. This should take less than 2 minutes.");
@@ -164,8 +346,9 @@ namespace CompatibilityReport.Updater
             int pageNumber = 0;
             int newMapThemes = 0;
 
+            int maxListingPages = GlobalConfig.Instance.UpdaterConfig.SteamMaxListingPages;
             // Download and read pages until we find no more map themes, or we reach a maximum number of pages, to avoid missing the mark and continuing for eternity.
-            while (pageNumber < ModSettings.SteamMaxListingPages)
+            while (pageNumber < maxListingPages)
             {
                 pageNumber++;
                 int mapThemesFoundThisPage = 0;
@@ -219,15 +402,98 @@ namespace CompatibilityReport.Updater
             Toolkit.DeleteFile(ModSettings.TempDownloadFullPath);
             Logger.UpdaterLog($"Updater finished downloading { pageNumber } Steam Workshop 'map themes listing' pages and found { newMapThemes } new map themes.");
         }
-
-
-    /// <summary>Downloads individual mod pages from the Steam Workshop to get detailed mod information for all mods in the catalog.</summary>
-    /// <remarks>Known unlisted mods are included. Removed mods are checked, to catch reappearing mods.</remarks>
-    private static void GetDetails(Catalog catalog)
+        
+        
+        /// <summary>Downloads 'Map Theme listing' pages from the Steam Workshop to get Steam IDs for all available map themes.</summary>
+        /// <remarks>The Steam IDs will be added to the list of Map Themes.</remarks>
+        private static IEnumerator GetMapThemesWithProgress(Catalog catalog, ProgressMonitor progressMonitor)
         {
+            Logger.UpdaterLog("Updater started downloading Steam Workshop 'map theme listing' pages. This should take less than 2 minutes.");
+
+            string steamUrl = ModSettings.SteamMapThemesListingUrl;
+            int pageNumber = 0;
+            int newMapThemes = 0;
+
+            int maxListingPages = GlobalConfig.Instance.UpdaterConfig.SteamMaxListingPages;
+            
+            progressMonitor.StartProgress(maxListingPages, $"Starting Map Themes download, num of pages {maxListingPages}", true);
+            progressMonitor.UpdateStage(6, 8);
+            progressMonitor.PushMessage($"Starting Map Themes download, number of pages <color #00ff00>{maxListingPages}</color>");
+            
+            // Download and read pages until we find no more map themes, or we reach a maximum number of pages, to avoid missing the mark and continuing for eternity.
+            while (pageNumber < maxListingPages)
+            {
+                pageNumber++;
+                int mapThemesFoundThisPage = 0;
+                string url = $"{ steamUrl }&p={ pageNumber }";
+
+                progressMonitor.ReportProgress(pageNumber, $"Downloading page {pageNumber} of {maxListingPages}");
+                KeyValuePair<bool, string> stateWithText = new KeyValuePair<bool, string>();
+                yield return Toolkit.DownloadPageText(url, result => stateWithText = result);
+                
+                if (!stateWithText.Key)
+                {
+                    Logger.UpdaterLog($"Download process interrupted due to a permanent error while downloading { url }", Logger.Error);
+
+                    pageNumber--;
+                    progressMonitor.Abort();
+                    break;
+                }
+
+                string line;
+                int index = 0;
+                string[] lines = stateWithText.Value.Split('\n');
+
+                while (index < lines.Length)
+                {
+                    line = lines[index++];
+                    // Search for the identifying string for the next map theme; continue with next line if not found.
+                    if (!line.Contains(ModSettings.SearchModStart))
+                    {
+                        continue;
+                    }
+
+                    ulong steamID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchSteamIDLeft, ModSettings.SearchSteamIDRight));
+
+                    if (steamID == 0)
+                    {
+                        Logger.UpdaterLog($"Steam ID not recognized on HTML line: { line }", Logger.Error);
+                        continue;
+                    }
+
+                    // Add the found map theme Steam ID only if that Steam ID is not a valid mod in the catalog.
+                    if (catalog.IsValidID(steamID, shouldExist: false) && catalog.AddMapTheme(steamID))
+                    {
+                        newMapThemes++;
+                    }
+
+                    mapThemesFoundThisPage++;
+                }
+
+                if (mapThemesFoundThisPage == 0)
+                {
+                    pageNumber--;
+                    break;
+                }
+            }
+
+            Logger.UpdaterLog($"Updater finished downloading { pageNumber } Steam Workshop 'map themes listing' pages and found { newMapThemes } new map themes.");
+            
+            progressMonitor.PushMessage($"Finished downloading <color #00ff00>{pageNumber}</color> Steam Workshop 'map themes listing' pages and found <color #00ff00>{newMapThemes}</color> new map themes.");
+            progressMonitor.ReportProgress(maxListingPages, $"Finished downloading <color #00ff00>{ pageNumber }</color> 'map themes listing' pages");
+            yield return null;
+        }
+
+
+        /// <summary>Downloads individual mod pages from the Steam Workshop to get detailed mod information for all mods in the catalog.</summary>
+        /// <remarks>Known unlisted mods are included. Removed mods are checked, to catch reappearing mods.</remarks>
+        [Obsolete("Replaced to support reporting progress to UI")]
+        private static void GetDetails(Catalog catalog)
+        {
+            UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
             Stopwatch timer = Stopwatch.StartNew();
             int numberOfMods = catalog.Mods.Count - ModSettings.BuiltinMods.Count;
-            long estimatedMilliseconds = ModSettings.EstimatedMillisecondsPerModPage * numberOfMods;
+            long estimatedMilliseconds = updaterConfig.EstimatedMillisecondsPerModPage * numberOfMods;
 
             Logger.UpdaterLog($"Updater started downloading { numberOfMods } individual Steam Workshop mod pages. This should take about " +
                 $"{ Toolkit.TimeString(estimatedMilliseconds) } and should be ready around { DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30*1000):HH:mm}.");
@@ -249,7 +515,7 @@ namespace CompatibilityReport.Updater
 
                     Logger.UpdaterLog($"Permanent error while downloading Steam Workshop page for { catalogMod.ToString() }. Details not updated.", Logger.Error);
 
-                    if (failedDownloads <= ModSettings.SteamMaxFailedPages)
+                    if (failedDownloads <= updaterConfig.SteamMaxFailedPages)
                     {
                         continue;
                     }
@@ -287,6 +553,92 @@ namespace CompatibilityReport.Updater
             // Note: about 90% of the total time is downloading, the other 10% is processing.
             Logger.UpdaterLog($"Updater finished downloading { modsDownloaded } individual Steam Workshop mod pages in " + 
                 $"{ Toolkit.TimeString(timer.ElapsedMilliseconds, alwaysShowSeconds: true) }.");
+        }
+
+        /// <summary>Downloads individual mod pages from the Steam Workshop to get detailed mod information for all mods in the catalog.</summary>
+        /// <remarks>Known unlisted mods are included. Removed mods are checked, to catch reappearing mods.</remarks>
+        private static IEnumerator GetDetailsWithProgress(Catalog catalog, ProgressMonitor monitor)
+        {
+            UpdaterConfig updaterConfig = GlobalConfig.Instance.UpdaterConfig;
+            Stopwatch timer = Stopwatch.StartNew();
+            int numberOfMods = catalog.Mods.Count - ModSettings.BuiltinMods.Count;
+            long estimatedMilliseconds = updaterConfig.EstimatedMillisecondsPerModPage * numberOfMods;
+    
+            monitor.StartProgress(numberOfMods, $"Started downloading <color #00FF00>{ numberOfMods }</color> Workshop mod pages", true);
+            monitor.UpdateStage(5, 8);
+            monitor.PushMessage($"Started downloading <color #00ff00>{ numberOfMods }</color> Workshop mod pages.\n" +
+                $"This should take about <color #00ff00>{ Toolkit.TimeString(estimatedMilliseconds) }</color>" +
+                $" and should be ready around <color #00ff00>{ DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30*1000):HH:mm}</color>.");
+            
+            Logger.UpdaterLog($"Updater started downloading { numberOfMods } individual Steam Workshop mod pages. This should take about " +
+                $"{ Toolkit.TimeString(estimatedMilliseconds) } and should be ready around { DateTime.Now.AddMilliseconds(estimatedMilliseconds + 30*1000):HH:mm}.");
+    
+            int modsDownloaded = 0;
+            int failedDownloads = 0;
+
+            foreach (Mod catalogMod in catalog.Mods)
+            {
+                if (!catalog.IsValidID(catalogMod.SteamID, allowBuiltin: false))
+                {
+                    // Skip built-in mods.
+                    continue;
+                }
+
+                KeyValuePair<bool, string> statusWithText = new KeyValuePair<bool, string>();
+                yield return Toolkit.DownloadPageText(Toolkit.GetWorkshopUrl(catalogMod.SteamID), result => statusWithText = result);
+                
+                if (!statusWithText.Key)
+                {
+                    failedDownloads++;
+    
+                    Logger.UpdaterLog($"Permanent error while downloading Steam Workshop page for { catalogMod.ToString() }. Details not updated.", Logger.Error);
+    
+                    if (failedDownloads <= updaterConfig.SteamMaxFailedPages)
+                    {
+                        monitor.ReportProgress(modsDownloaded, $"Downloaded <color #00ff00>{ modsDownloaded }</color> of <color #16a085>{ numberOfMods }</color>, <color #ff0000>{ failedDownloads }</color> failed");
+                        continue;
+                    }
+                    else
+                    {
+                        Logger.UpdaterLog("Download process stopped prematurely.", Logger.Error);
+                        monitor.Abort();
+                        break;
+                    }
+                }
+    
+                modsDownloaded++;
+                monitor.ReportProgress(modsDownloaded, $"Downloaded <color #00ff00>{modsDownloaded}</color> of <color #16a085>{numberOfMods}</color>, <color #ff0000>{failedDownloads}</color> failed");
+    
+                if (modsDownloaded % 100 == 0)
+                {
+                    Logger.UpdaterLog($"{ modsDownloaded }/{ numberOfMods } mod pages downloaded.");
+                }
+    
+                if (!ReadModPageText(catalog, catalogMod, statusWithText.Value))
+                {
+                    // Redownload and try one more time, to work around cut-off downloads.
+                    monitor.PushMessage("<color #ffc107>Could not read mod page, retrying...</color>");
+                    yield return Toolkit.DownloadPageText(Toolkit.GetWorkshopUrl(catalogMod.SteamID), result => statusWithText = result);
+                    
+                    if (!ReadModPageText(catalog, catalogMod, statusWithText.Value))
+                    {
+                        monitor.PushMessage($"<color #ff0000>Mod info not updated for { catalogMod.ToString() }.</color>");
+                        Logger.UpdaterLog($"Mod info not updated for { catalogMod.ToString() }.", Logger.Error);
+                    }
+                    else
+                    {
+                        Logger.UpdaterLog($"Steam page correctly read on retry for { catalogMod.ToString() }. Mod info updated.");
+                    }
+                }
+            }
+    
+            // Note: about 90% of the total time is downloading, the other 10% is processing.
+            Logger.UpdaterLog($"Updater finished downloading { modsDownloaded } individual Steam Workshop mod pages in " + 
+                $"{ Toolkit.TimeString(timer.ElapsedMilliseconds, alwaysShowSeconds: true) }.");
+            
+            monitor.ReportProgress(numberOfMods, $"Finished downloading <color #00ff00>{ modsDownloaded }</color> Steam Workshop mod pages");
+            monitor.PushMessage($"Updater finished downloading <color #00ff00>{ modsDownloaded }</color> individual Steam Workshop mod pages\n" +
+                $"in { Toolkit.TimeString(timer.ElapsedMilliseconds, alwaysShowSeconds: true) }.");
         }
 
 
@@ -460,6 +812,7 @@ namespace CompatibilityReport.Updater
                         // Get all required items from the next lines, until we find no more. Max. 50 times to avoid an infinite loop.
                         for (var i = 1; i <= 50; i++)
                         {
+                            //todo are you sure it won't be null here (end of file)?
                             line = reader.ReadLine();
                             ulong requiredID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchRequiredModLeft, ModSettings.SearchRequiredModRight));
 
@@ -547,6 +900,284 @@ namespace CompatibilityReport.Updater
                 // We didn't find a Steam ID on the page, but no error page either. Must be a download issue or another Steam error.
                 Toolkit.CopyFile(ModSettings.TempDownloadFullPath, Path.Combine(ModSettings.UpdaterPath, $"{ catalogMod.SteamID } - error.html"));
 
+                Logger.UpdaterLog($"Can't find the Steam ID on downloaded page for { catalogMod.ToString() }. Downloaded page saved.", Logger.Warning);
+                return false;
+            }
+
+            foreach (Enums.Dlc oldRequiredDlc in RequiredDlcsToRemove)
+            {
+                CatalogUpdater.RemoveRequiredDlc(catalog, catalogMod, oldRequiredDlc);
+            }
+
+            return true;
+        }
+
+        /// <summary>Extracts detailed mod information from a downloaded mod page and updates the catalog.</summary>
+        /// <returns>True if successful, false if there was an error with the mod page.</returns>
+        public static bool ReadModPageText(Catalog catalog, Mod catalogMod, string pageText)
+        {
+            List<Enums.Dlc> RequiredDlcsToRemove = new List<Enums.Dlc>(catalogMod.RequiredDlcs);
+            bool steamIDmatched = false;
+            string line;
+            int lineIndex = 0;
+            string[] lines = pageText.Split('\n');
+            
+            while (lineIndex++ < lines.Length)
+            {
+                line = lines[lineIndex];
+                if (!steamIDmatched)
+                {
+                    steamIDmatched = line.Contains($"{ ModSettings.SearchSteamID }{catalogMod.SteamID}");
+
+                    if (steamIDmatched)
+                    {
+                        CatalogUpdater.RemoveStatus(catalog, catalogMod, Enums.Status.RemovedFromWorkshop);
+
+                        if (!catalogMod.UpdatedThisSession)
+                        {
+                            // Set the unlisted status. Also update the auto review date, which is already done for all listed mods.
+                            CatalogUpdater.AddStatus(catalog, catalogMod, Enums.Status.UnlistedInWorkshop);
+                            CatalogUpdater.UpdateMod(catalog, catalogMod);
+                        }
+                    }
+
+                    else if (line.Contains(ModSettings.SearchItemNotFound))
+                    {
+                        if (catalogMod.UpdatedThisSession)
+                        {
+                            Logger.UpdaterLog($"We found this mod, but can't read the Steam page for { catalogMod.ToString() }.", Logger.Warning);
+                            return false;
+                        }
+                        else
+                        {
+                            CatalogUpdater.AddStatus(catalog, catalogMod, Enums.Status.RemovedFromWorkshop);
+                            return true;
+                        }
+                    }
+
+                    // Keep reading lines until we find the Steam ID.
+                    continue;
+                }
+
+                // Author Steam ID, Custom URL and author name.
+                if (line.Contains(ModSettings.SearchAuthorLeft))
+                {
+                    // Only get the author URL if the author ID was not found, to prevent updating the author URL to an empty string.
+                    ulong authorID = Toolkit.ConvertToUlong(Toolkit.MidString(line, $"{ ModSettings.SearchAuthorLeft }profiles/", ModSettings.SearchAuthorMid));
+                    string authorUrl = authorID != 0 ? null : Toolkit.MidString(line, $"{ ModSettings.SearchAuthorLeft }id/", ModSettings.SearchAuthorMid);
+
+                    // Author name needs to be cleaned twice because of how it is presented in the HTML source.
+                    string authorName = Toolkit.CleanHtml(Toolkit.CleanHtml(Toolkit.MidString(line, ModSettings.SearchAuthorMid, ModSettings.SearchAuthorRight)));
+
+                    // Try to get the author with ID/URL from the mod, to prevent creating a new author on an ID/URL change or when Steam gives ID instead of URL.
+                    // On a new mod that fails, so try the newly found ID/URL. If it still fails we have an unknown author, so create a new author.
+                    // Todo 1.x This is not foolproof and we can still accidentally create a new author on new mods. Requires Steam API for better reliability.
+                    Author catalogAuthor = catalog.GetAuthor(catalogMod.AuthorID, catalogMod.AuthorUrl) ?? catalog.GetAuthor(authorID, authorUrl) ??
+                        CatalogUpdater.AddAuthor(catalog, authorID, authorUrl, authorName);
+
+                    if (authorName == "")
+                    {
+                        if (string.IsNullOrEmpty(catalogAuthor.Name))
+                        {
+                            Logger.UpdaterLog($"Author found without a name: { catalogAuthor.ToString() }.", Logger.Error);
+                        }
+
+                        // Don't update the name to an empty string.
+                        authorName = null;
+                    }
+                    else if (authorName == authorID.ToString() && authorID != 0 && (authorName != catalogAuthor.Name || catalogAuthor.AddedThisSession) &&
+                        !catalog.SuppressedWarnings.Contains(authorID))
+                    {
+                        // An author name equal to the author ID is a common Steam error, although some authors really have their ID as name (ofcourse they do).
+                        if (string.IsNullOrEmpty(catalogAuthor.Name) || catalogAuthor.AddedThisSession)
+                        {
+                            Logger.UpdaterLog($"Author found with Steam ID as name: { authorName }. Some authors do this, but it could be a Steam error.", 
+                                Logger.Warning);
+                        }
+                        else
+                        {
+                            Logger.UpdaterLog($"Author found with Steam ID as name: { authorName }. Old name still used: { catalogAuthor.Name }.");
+                        }
+
+                        // Don't update the name if we already know a name.
+                        authorName = string.IsNullOrEmpty(catalogAuthor.Name) ? authorName : null;
+                    }
+
+                    // Update the author. All mods from the author will be updated, including this one if it already existed in the catalog.
+                    CatalogUpdater.UpdateAuthor(catalog, catalogAuthor, authorID, authorUrl, authorName, updatedByImporter: false);
+
+                    // Still need to update the mod if this is a new mod.
+                    CatalogUpdater.UpdateMod(catalog, catalogMod, authorID: catalogAuthor.SteamID, authorUrl: catalogAuthor.CustomUrl);
+                }
+
+                // Mod name.
+                else if (line.Contains(ModSettings.SearchModNameLeft))
+                {
+                    string modName = Toolkit.CleanHtml(Toolkit.MidString(line, ModSettings.SearchModNameLeft, ModSettings.SearchModNameRight));
+
+                    if (string.IsNullOrEmpty(modName) && !catalog.SuppressedWarnings.Contains(catalogMod.SteamID))
+                    {
+                        // An empty mod name might be an error, although there is a Steam Workshop mod without a name (ofcourse there is).
+                        Logger.UpdaterLog($"Mod name not found for { catalogMod.SteamID }. This could be an actual unnamed mod, or a Steam error.", Logger.Warning);
+                    }
+
+                    CatalogUpdater.UpdateMod(catalog, catalogMod, modName);
+                }
+
+                // Compatible game version tag
+                else if (line.Contains(ModSettings.SearchVersionTag))
+                {
+                    // Convert the found tag to a game version and back to a formatted game version string, so we have a consistently formatted string.
+                    string gameVersionString = Toolkit.MidString(line, ModSettings.SearchVersionTagLeft, ModSettings.SearchVersionTagRight);
+                    Version gameVersion = Toolkit.ConvertToVersion(gameVersionString);
+                    gameVersionString = Toolkit.ConvertGameVersionToString(gameVersion);
+
+                    if (!catalogMod.ExclusionForGameVersion || gameVersion >= catalogMod.GameVersion())
+                    {
+                        CatalogUpdater.UpdateMod(catalog, catalogMod, gameVersionString: gameVersionString);
+                        catalogMod.UpdateExclusions(exclusionForGameVersion: false);
+                    }
+                }
+
+                // Publish and update dates.
+                else if (line.Contains(ModSettings.SearchDates))
+                {
+                    lineIndex += 2;
+                    line = lines[lineIndex];
+                    // line = reader.ReadLine();
+                    // line = reader.ReadLine();
+                    DateTime published = Toolkit.ConvertWorkshopDateTime(Toolkit.MidString(line, ModSettings.SearchDatesLeft, ModSettings.SearchDatesRight));
+                    
+                    line = lines[++lineIndex];
+                    // line = reader.ReadLine();
+                    DateTime updated = Toolkit.ConvertWorkshopDateTime(Toolkit.MidString(line, ModSettings.SearchDatesLeft, ModSettings.SearchDatesRight));
+
+                    CatalogUpdater.UpdateMod(catalog, catalogMod, published: published, updated: updated);
+                }
+
+                // Required DLC. This line can be found multiple times.
+                else if (line.Contains(ModSettings.SearchRequiredDlc))
+                {
+                    line = lines[++lineIndex];
+                    // line = reader.ReadLine();
+                    Enums.Dlc dlc = Toolkit.ConvertToEnum<Enums.Dlc>(Toolkit.MidString(line, ModSettings.SearchRequiredDlcLeft, ModSettings.SearchRequiredDlcRight));
+
+                    if (dlc != default)
+                    {
+                        if (catalogMod.ExclusionForRequiredDlcs.Contains(dlc) && catalogMod.RequiredDlcs.Contains(dlc))
+                        {
+                            // This required DLC was manually added (thus the exclusion), but was now found on the Steam page. The exclusion is no longer needed.
+                            catalogMod.RemoveExclusion(dlc);
+                        }
+
+                        // If an exclusion exists at this point, then it's about a required DLC that was manually removed. Don't add it again.
+                        if (!catalogMod.ExclusionForRequiredDlcs.Contains(dlc))
+                        {
+                            CatalogUpdater.AddRequiredDlc(catalog, catalogMod, dlc);
+                            RequiredDlcsToRemove.Remove(dlc);
+                        }
+                    }
+                }
+
+                // Required mods and assets. The search string is a container with all required items on the next lines.
+                else if (line.Contains(ModSettings.SearchRequiredMod))
+                {
+                    List<ulong> RequiredModsToRemove = new List<ulong>(catalogMod.RequiredMods);
+
+                    // Get all required items from the next lines, until we find no more. Max. 50 times to avoid an infinite loop.
+                    for (var i = 1; i <= 50; i++)
+                    {
+                        line = lines[++lineIndex];
+                        // line = reader.ReadLine();
+                        ulong requiredID = Toolkit.ConvertToUlong(Toolkit.MidString(line, ModSettings.SearchRequiredModLeft, ModSettings.SearchRequiredModRight));
+
+                        if (requiredID == 0)
+                        {
+                            break;
+                        }
+
+                        if (catalogMod.ExclusionForRequiredMods.Contains(requiredID) && catalogMod.RequiredMods.Contains(requiredID))
+                        {
+                            // This required mod was manually added (thus the exclusion), but was now found on the Steam page. The exclusion is no longer needed.
+                            catalogMod.RemoveExclusion(requiredID);
+                        }
+
+                        // If an exclusion exists at this point, then it's about a required mod that was manually removed. Don't add it again.
+                        if (!catalogMod.ExclusionForRequiredMods.Contains(requiredID))
+                        {
+                            CatalogUpdater.AddRequiredMod(catalog, catalogMod, requiredID, updatedByImporter: false);
+                            RequiredModsToRemove.Remove(requiredID);
+                        }
+                        lineIndex += 3;
+                        line = lines[lineIndex];
+
+                        // line = reader.ReadLine();
+                        // line = reader.ReadLine();
+                        // line = reader.ReadLine();
+                    }
+
+                    foreach (ulong oldRequiredID in RequiredModsToRemove)
+                    {
+                        if (!catalogMod.ExclusionForRequiredMods.Contains(oldRequiredID))
+                        {
+                            CatalogUpdater.RemoveRequiredMod(catalog, catalogMod, oldRequiredID, updatedByImporter: false);
+                        }
+                    }
+                }
+
+                // Description for 'no description' status and for source URL.
+                else if (line.Contains(ModSettings.SearchDescription))
+                {
+                    line = lines[lineIndex];
+                    // We can't search for the right part, because it might exist inside the description.
+                    StringBuilder descriptionSB = new StringBuilder(Toolkit.MidString($"{ line }\n", ModSettings.SearchDescriptionLeft, "\n"));
+
+                    // Usually, the complete description is on one line. However, it might be split when using certain bbcode. Combine up to 30 lines.
+                    for (var i = 1; i <= 30; i++)
+                    {
+                        line = lines[++lineIndex];
+                        // line = reader.ReadLine();
+
+                        // Break out of the for loop when a line is found that marks the end of the description.
+                        if (line == ModSettings.SearchDescriptionNextLine || line == ModSettings.SearchDescriptionNextSection)
+                        {
+                            break;
+                        }
+
+                        descriptionSB.Append(line);
+                    }
+
+                    // A 'no description' status is when the description is not at least a few characters longer than the mod name.
+                    int noDescriptionThreshold = catalogMod.Name.Length + 3 + ModSettings.SearchDescriptionRight.Length;
+
+                    if ((descriptionSB.Length <= noDescriptionThreshold) && !catalogMod.ExclusionForNoDescription)
+                    {
+                        CatalogUpdater.AddStatus(catalog, catalogMod, Enums.Status.NoDescription);
+                    }
+                    else
+                    {
+                        if ((descriptionSB.Length > noDescriptionThreshold) && !catalogMod.ExclusionForNoDescription)
+                        {
+                            CatalogUpdater.RemoveStatus(catalog, catalogMod, Enums.Status.NoDescription);
+                        }
+
+                        // Try to find the source URL, unless an exception exists.
+                        if (!catalogMod.ExclusionForSourceUrl)
+                        {
+                            CatalogUpdater.UpdateMod(catalog, catalogMod, sourceUrl: GetSourceUrl(descriptionSB.ToString(), catalogMod));
+                        }
+                    }
+
+                    // Description is the last info we need from the page, so break out of the while loop.
+                    break;
+                }
+            }
+
+            if (!steamIDmatched && !catalogMod.Statuses.Contains(Enums.Status.RemovedFromWorkshop))
+            {
+                // We didn't find a Steam ID on the page, but no error page either. Must be a download issue or another Steam error.
+                File.WriteAllText(Path.Combine(ModSettings.UpdaterPath, $"{ catalogMod.SteamID } - error.html"), pageText);
+                
                 Logger.UpdaterLog($"Can't find the Steam ID on downloaded page for { catalogMod.ToString() }. Downloaded page saved.", Logger.Warning);
                 return false;
             }

--- a/CompatibilityReport/Util/GameObjectObserver.cs
+++ b/CompatibilityReport/Util/GameObjectObserver.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using UnityEngine;
+
+namespace CompatibilityReport.Util
+{
+    /// <summary>
+    /// Simple component which should be if we are not managing gameObject lifecycle
+    /// OnDestroy will be automatically called upon gameObject destroy, will trigger event
+    /// Event is perfect for performing clean up of events or other memory leak prone code
+    /// </summary>
+    public class GameObjectObserver : MonoBehaviour
+    {
+        public event Action eventGameObjectDestroyed;
+        private void OnDestroy()
+        {
+            try
+            {
+                eventGameObjectDestroyed?.Invoke();
+                eventGameObjectDestroyed = null;
+            }
+            catch (Exception e)
+            {
+                Logger.Exception(e);
+            }
+        }
+    }
+}

--- a/CompatibilityReport/Util/Logger.cs
+++ b/CompatibilityReport/Util/Logger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using CompatibilityReport.Settings;
 
 // This class is based on the Logger class from Enhanced District Services by Tim / chronofanz:
 // https://github.com/chronofanz/EnhancedDistrictServices/blob/master/Source/Logger.cs
@@ -58,7 +59,7 @@ namespace CompatibilityReport.Util
         /// <summary>Logs a message to the updater log.</summary>
         public static void UpdaterLog(string message, LogLevel logLevel = LogLevel.Info)
         {
-            if ((logLevel == Debug) && !ModSettings.DebugMode)
+            if ((logLevel == Debug) && !GlobalConfig.Instance.AdvancedConfig.DebugMode)
             {
                 return;
             }
@@ -78,14 +79,22 @@ namespace CompatibilityReport.Util
         /// <summary>Closes the updater log.</summary>
         public static void CloseUpdaterLog()
         {
+            updaterLog?.Dispose();
             updaterLog = null;
+        }
+        
+        /// <summary>Closes the debug log.</summary>
+        public static void CloseDebugLog()
+        {
+            debugLog?.Dispose();
+            debugLog = null;
         }
 
 
         /// <summary>Logs an exception to this mods log or updater log, and to the game log unless indicated otherwise.</summary>
         public static void Exception(Exception ex, LogLevel logLevel = LogLevel.Info)
         {
-            if ((logLevel == Debug) && !ModSettings.DebugMode)
+            if ((logLevel == Debug) && !GlobalConfig.Instance.AdvancedConfig.DebugMode)
             {
                 return;
             }
@@ -108,7 +117,7 @@ namespace CompatibilityReport.Util
 
 
         /// <summary>The LogFiler class writes the logging to file.</summary>
-        private class LogFiler
+        private class LogFiler : IDisposable
         {
             private readonly StreamWriter file;
             private readonly string logfileFullPath;
@@ -129,7 +138,7 @@ namespace CompatibilityReport.Util
                     {
                         file = File.CreateText(logfileFullPath);
                     }
-                    else if (append && (new FileInfo(logfileFullPath).Length < ModSettings.LogMaxSize))
+                    else if (append && (new FileInfo(logfileFullPath).Length < GlobalConfig.Instance.AdvancedConfig.LogMaxSize))
                     {
                         file = File.AppendText(logfileFullPath);
 
@@ -191,7 +200,7 @@ namespace CompatibilityReport.Util
                     GameLog($"{ logLevelPrefix }{ message }");
                 }
 
-                if (ModSettings.DebugMode)
+                if (GlobalConfig.Instance.AdvancedConfig.DebugMode)
                 {
                     string lowerCaseMessage = message.ToLower();
                     if (lowerCaseMessage.Contains("\\appdata\\local") || lowerCaseMessage.Contains("c:\\users\\") || lowerCaseMessage.Contains("/users/"))
@@ -199,6 +208,11 @@ namespace CompatibilityReport.Util
                         Log("Previously logged path probably needs more privacy.", LogLevel.Debug);
                     }
                 }
+            }
+
+            public void Dispose()
+            {
+                file?.Dispose();
             }
         }
     }

--- a/CompatibilityReport/Util/ModSettings.cs
+++ b/CompatibilityReport/Util/ModSettings.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using UnityEngine;
 using ColossalFramework.IO;
+using CompatibilityReport.Settings;
 
 namespace CompatibilityReport.Util
 {
@@ -9,7 +10,12 @@ namespace CompatibilityReport.Util
     {
         // Mod properties.
         public const string Version = "0.8.0";
-        public const string Build = "430";
+#if DEBUG
+        // allow for hot-swapping the mod - rebuild only if it's in the main menu, game will detect and reload the mod
+        public const string Build = "*";
+#else
+        public const string Build = "431";
+#endif
         public const string ReleaseType = "";
         public const int CurrentCatalogStructureVersion = 5;
 
@@ -55,9 +61,6 @@ namespace CompatibilityReport.Util
         public static string AlternativeReportPath { get; } = DataLocation.localApplicationData;
         public const string ReportTextFileName = InternalName + ".txt";
         public const string ReportHtmlFileName = InternalName + ".html";
-
-        public static string SettingsPath { get; } = DataLocation.applicationBase;
-        public const string SettingsFileName = InternalName + "_Settings.xml";
 
         public static string DebugLogPath { get; } = Path.Combine(Application.dataPath, "Logs");
         public const string LogFileName = InternalName + ".log";
@@ -131,22 +134,13 @@ namespace CompatibilityReport.Util
         // Miscellaneous settings
         public static string SettingsUIColor = "#FF8C00";
 
-
-        // Todo 0.8 Settings that will be available to users through mod options within the game.
-        public static string ReportPath { get; private set; } = DefaultReportPath;
-        public static int TextReportWidth { get; private set; } = MinimalTextReportWidth;
-        public static bool ReportSortByName { get; private set; } = true;
-        public static bool HtmlReport { get; private set; } = false;
-        public static bool TextReport { get; private set; } = true;
-        public static bool AllowOnDemandScanning { get; private set; } = false;
-
-
-        // Todo 0.8 Settings that will be available in a settings xml file.
-        public static int DownloadRetries { get; private set; } = 4;
-        public static bool ScanBeforeMainMenu { get; private set; } = true;
-        public static bool DebugMode { get; private set; } = !string.IsNullOrEmpty(ReleaseType) || File.Exists(Path.Combine(WorkPath, $"{ InternalName }_Debug.enabled"));
-        public static long LogMaxSize { get; private set; } = 100 * 1024;
-
+        public static bool DebugMode =>
+#if DEBUG
+            true;
+#else
+            GlobalConfig.Instance?.AdvancedConfig?.DebugMode ?? false;
+#endif
+        public static int TextReportWidth => GlobalConfig.Instance.GeneralConfig.TextReportWidth;
 
         // Updater properties.
         public static string UpdaterPath { get; } = Path.Combine(WorkPath, $"{ InternalName }Updater");
@@ -154,6 +148,7 @@ namespace CompatibilityReport.Util
         public const string UpdaterSettingsFileName = InternalName + "_UpdaterSettings.xml";
         public const string UpdaterLogFileName = InternalName + "_Updater.log";
         public const string DataDumpFileName = InternalName + "_DataDump.txt";
+        public const string CatalogDumpFileName = InternalName + "_CatalogDump.xml";
         public const string OneTimeActionFileName = InternalName + "_OneTimeAction.txt";
 
         public static string FakeSubscriptionsFileFullPath { get; } = Path.Combine(WorkPath, $"{ InternalName }_FakeSubscriptions.txt");
@@ -236,17 +231,6 @@ namespace CompatibilityReport.Util
             "translation",
             "blob"
         };
-
-
-        // Todo 0.8 Defaults for updater settings that will be available in an updater settings xml file.
-        public static bool UpdaterEnabled { get; private set; } = true;
-        public static bool WebCrawlerEnabled { get; private set; } = File.Exists(Path.Combine(UpdaterPath, $"{ InternalName }_WebCrawler.enabled"));
-        public static bool UpdaterOneTimeActionEnabled { get; private set; } = File.Exists(Path.Combine(UpdaterPath, $"{ InternalName }_OneTimeAction.enabled"));
-        public static int SteamMaxFailedPages { get; private set; } = 4;
-        public static int SteamMaxListingPages { get; private set; } = 300;
-        public static int EstimatedMillisecondsPerModPage { get; private set; } = 500;
-        public static int DaysOfInactivityToRetireAuthor { get; private set; } = 365;
-        public static int WeeksForSoonRetired { get; private set; } = 2;
 
         public const string FeedbackFormUrl = "https://forms.gle/PvezwfpgS1V1DHqA9";
 

--- a/CompatibilityReport/Util/ModSettings.cs
+++ b/CompatibilityReport/Util/ModSettings.cs
@@ -14,7 +14,7 @@ namespace CompatibilityReport.Util
         // allow for hot-swapping the mod - rebuild only if it's in the main menu, game will detect and reload the mod
         public const string Build = "*";
 #else
-        public const string Build = "433";
+        public const string Build = "434";
 #endif
         public const string ReleaseType = "";
         public const int CurrentCatalogStructureVersion = 5;
@@ -115,9 +115,6 @@ namespace CompatibilityReport.Util
         // either need an 'unsafe' webserver that still support TLS 1.1, or a HTTP only site. Or switch to .NET 4.5+ or
         // use UnityWebRequest and use a Coroutine setup on a MonoBehaviour.
         public const string CatalogUrl = "https://drive.google.com/uc?export=download&id=1P8hakzFi2ydlXGybx5aatuggSW7RpBYG";
-
-        // Report and log properties.
-        public const int MinimalTextReportWidth = 90;
 
         public const string Bullet1 = " - ";
         public const string Indent1 = "   ";

--- a/CompatibilityReport/Util/ModSettings.cs
+++ b/CompatibilityReport/Util/ModSettings.cs
@@ -9,7 +9,7 @@ namespace CompatibilityReport.Util
     {
         // Mod properties.
         public const string Version = "0.7.6";
-        public const string Build = "428";
+        public const string Build = "429";
         public const string ReleaseType = "";
         public const int CurrentCatalogStructureVersion = 4;
 
@@ -151,6 +151,7 @@ namespace CompatibilityReport.Util
         public const string UpdaterSettingsFileName = InternalName + "_UpdaterSettings.xml";
         public const string UpdaterLogFileName = InternalName + "_Updater.log";
         public const string DataDumpFileName = InternalName + "_DataDump.txt";
+        public const string OneTimeActionFileName = InternalName + "_OneTimeAction.txt";
 
         public static string FakeSubscriptionsFileFullPath { get; } = Path.Combine(WorkPath, $"{ InternalName }_FakeSubscriptions.txt");
 
@@ -237,9 +238,10 @@ namespace CompatibilityReport.Util
         // Todo 0.8 Defaults for updater settings that will be available in an updater settings xml file.
         public static bool UpdaterEnabled { get; private set; } = true;
         public static bool WebCrawlerEnabled { get; private set; } = File.Exists(Path.Combine(UpdaterPath, $"{ InternalName }_WebCrawler.enabled"));
+        public static bool UpdaterOneTimeActionEnabled { get; private set; } = File.Exists(Path.Combine(UpdaterPath, $"{ InternalName }_OneTimeAction.enabled"));
         public static int SteamMaxFailedPages { get; private set; } = 4;
         public static int SteamMaxListingPages { get; private set; } = 300;
-        public static int EstimatedMillisecondsPerModPage { get; private set; } = 550;
+        public static int EstimatedMillisecondsPerModPage { get; private set; } = 500;
         public static int DaysOfInactivityToRetireAuthor { get; private set; } = 365;
         public static int WeeksForSoonRetired { get; private set; } = 2;
 

--- a/CompatibilityReport/Util/ModSettings.cs
+++ b/CompatibilityReport/Util/ModSettings.cs
@@ -8,10 +8,10 @@ namespace CompatibilityReport.Util
     public static class ModSettings
     {
         // Mod properties.
-        public const string Version = "0.7.6";
-        public const string Build = "429";
+        public const string Version = "0.8.0";
+        public const string Build = "430";
         public const string ReleaseType = "";
-        public const int CurrentCatalogStructureVersion = 4;
+        public const int CurrentCatalogStructureVersion = 5;
 
         public const string ModName = "Compatibility Report";
         public const string InternalName = "CompatibilityReport";
@@ -112,7 +112,6 @@ namespace CompatibilityReport.Util
         // either need an 'unsafe' webserver that still support TLS 1.1, or a HTTP only site. Or switch to .NET 4.5+ or
         // use UnityWebRequest and use a Coroutine setup on a MonoBehaviour.
         public const string CatalogUrl = "https://drive.google.com/uc?export=download&id=1P8hakzFi2ydlXGybx5aatuggSW7RpBYG";
-        // Todo 1.0 Remove this: old download URL: https://drive.google.com/uc?export=download&id=1oUT2U_PhLfW-KGWOyShHL2GvU6kyE4a2
 
         // Report and log properties.
         public const int MinimalTextReportWidth = 90;
@@ -127,6 +126,10 @@ namespace CompatibilityReport.Util
         public const string ReportTextForThisModVersion = "";
 
         public static string PleaseReportText { get; } = $"Please report this on the Steam Workshop page: { Toolkit.GetWorkshopUrl(OurOwnSteamID) }.";
+
+
+        // Miscellaneous settings
+        public static string SettingsUIColor = "#FF8C00";
 
 
         // Todo 0.8 Settings that will be available to users through mod options within the game.

--- a/CompatibilityReport/Util/ModSettings.cs
+++ b/CompatibilityReport/Util/ModSettings.cs
@@ -14,7 +14,7 @@ namespace CompatibilityReport.Util
         // allow for hot-swapping the mod - rebuild only if it's in the main menu, game will detect and reload the mod
         public const string Build = "*";
 #else
-        public const string Build = "431";
+        public const string Build = "433";
 #endif
         public const string ReleaseType = "";
         public const int CurrentCatalogStructureVersion = 5;
@@ -148,7 +148,7 @@ namespace CompatibilityReport.Util
         public const string UpdaterSettingsFileName = InternalName + "_UpdaterSettings.xml";
         public const string UpdaterLogFileName = InternalName + "_Updater.log";
         public const string DataDumpFileName = InternalName + "_DataDump.txt";
-        public const string CatalogDumpFileName = InternalName + "_CatalogDump.xml";
+        public const string CatalogDumpFileName = InternalName + "_WebCrawlerDump.xml";
         public const string OneTimeActionFileName = InternalName + "_OneTimeAction.txt";
 
         public static string FakeSubscriptionsFileFullPath { get; } = Path.Combine(WorkPath, $"{ InternalName }_FakeSubscriptions.txt");

--- a/CompatibilityReport/Util/ModSettings.cs
+++ b/CompatibilityReport/Util/ModSettings.cs
@@ -8,8 +8,8 @@ namespace CompatibilityReport.Util
     public static class ModSettings
     {
         // Mod properties.
-        public const string Version = "0.7.5";
-        public const string Build = "427";
+        public const string Version = "0.7.6";
+        public const string Build = "428";
         public const string ReleaseType = "";
         public const int CurrentCatalogStructureVersion = 4;
 
@@ -34,11 +34,11 @@ namespace CompatibilityReport.Util
         };
 
         public const ulong FakeAuthorIDforColossalOrder = 101;
-        public const ulong LowestLocalModID =            1001;
-        public const ulong HighestLocalModID =           9999;
-        public const ulong LowestGroupID =              10001;
-        public const ulong HighestGroupID =             99999;
-        public const ulong HighestFakeID =             999999;
+        public const ulong LowestLocalModID = 1001;
+        public const ulong HighestLocalModID = 9999;
+        public const ulong LowestGroupID = 10001;
+        public const ulong HighestGroupID = 99999;
+        public const ulong HighestFakeID = 999999;
 
 
         // Filenames and paths.
@@ -67,8 +67,8 @@ namespace CompatibilityReport.Util
         public const string OldDownloadedCatalogFileName = InternalName + "_Downloaded_Catalog.xml";
 
         public static string BundledCatalogFullPath
-        { 
-            get 
+        {
+            get
             {
                 try
                 {
@@ -151,6 +151,8 @@ namespace CompatibilityReport.Util
         public const string UpdaterSettingsFileName = InternalName + "_UpdaterSettings.xml";
         public const string UpdaterLogFileName = InternalName + "_Updater.log";
         public const string DataDumpFileName = InternalName + "_DataDump.txt";
+
+        public static string FakeSubscriptionsFileFullPath { get; } = Path.Combine(WorkPath, $"{ InternalName }_FakeSubscriptions.txt");
 
         public static string TempDownloadFullPath { get; } = Path.Combine(WorkPath, $"{ InternalName }_Download.tmp");
         public const string TempCsvCombinedFileName = InternalName + "_CSVCombined.tmp";

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Finwickle
+Copyright (c) 2022 Finwickle
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Compatibility Report version 0.7.5
+# Compatibility Report version 0.7.6
 
 Compatibility Report mod for [Cities: Skylines](https://steamcommunity.com/app/255710/workshop/). This reports compatibility issues and missing dependencies for your subscribed mods.
 

--- a/Todo.txt
+++ b/Todo.txt
@@ -1,0 +1,180 @@
+﻿TODO and IDEAS (also see roadmap in readme)
+===========================================
+
+* CURRENT VERSION
+    - Bugs / issues:
+        * Google Drive quota, resulting in no catalog update on some downloads
+        * Google Drive blocked in China, resulting in very slow game start (and no catalog update ofc.)
+    - Changes to CSV actions:
+        * new: Set_CompatibilityNote to add or replace a(n existing) compatibility note without changing the compatibility
+        * new: Remove_CompatibilityNote
+    - Changes to DataDumper:
+        * new: all with status NoCommentSection
+        * new: mods that require a broken (or worse) mod and have a stability better than broken themselves
+    - Other changes:
+        * detect certain local mods (name and/or mod path) and link them to Workshop mod through Steam ID
+            - create LocalMods in catalog, with the data for linking
+            - example: mod name "Update from GitHub", folder UpdateFromGitHub
+        * sort mods in compatibilities, so first mod is always lowest Steam ID
+            - including a one time sort of existing catalog data
+
+
+* 1.0 Mod Options
+    - settings xml
+	- on-demand catalog download
+	- on-demand report creation
+    - report format (text / html)
+    - report path
+	- schedule catalog download every time, once a day, once a week, never (on-demand only)
+    - option to show source URL and download date/time in report (default off)
+    - debug logging
+    - button to open the report and to open the Google Form
+    - ignore compatibilities between specific mods (planned for 1.x, not 0.7)
+    - maybe: compact report as option. Skip: retired author, abandoned mod, no source, ws url from "issues with", ...; maybe regular, compact, custom (with all options)
+    - examples for mod options: 
+        - https://skylines.paradoxwikis.com/Mod_Options_Panel
+        - https://github.com/keallu/CSL-StreamIt/blob/5df6d18acb2a8b4613c39ceab1fe0d37a8b3338b/StreamIt/StreamUtils.cs
+        - LSM: field for input, button to open text file, lines between categories
+        - AVO: button to open folder and website, version top right, field with last version/date, lines between categories
+        - MCC: button to open folder, lines between categories
+        - Autoline Color Redux: slider, dropdown, lines between categories
+        - FPS Booster: colored text
+
+
+* 1.1 Reporter
+    - new HTML layout (LoadingScreen style); categorize on issue severity
+    - keep track of some things for a summary warning: disabled mods, local (non built-in) mods, ...
+
+
+* 2.0 Steam API instead of crawler; requires Steam Web API user authentication key
+    - https://partner.steamgames.com/doc/webapi/IPublishedFileService
+    - https://partner.steamgames.com/doc/api/ISteamUGC#CreateQueryAllUGCRequest
+
+
+Other ideas
+    - Mod linking, for mods that aren't really mods but "settings" for other mods (like building themes)
+    - Succeeded by is minor issue or major issue category? (or its own?)
+    - Split minor issues into two categories? minor issues and: trivial issues / warnings / ???; Github #37
+    - Check Loading Order Mod/Tool for time zone issue fixes
+    - Put OS and memory info at the bottom of the report?
+    - Remove old mod change notes from catalog, or keep them all?
+    - Warnings about conflicting hotkeys that cannot be changed
+    - Standalone Updater tool; move Change Notes from Catalog to CatalogUpdater or something
+    - TLS issue, see https://steamcommunity.com/sharedfiles/filedetails/?id=2588499551 (comment 2-2-2022):
+      "You can't really get around the TLS issues, you have to approach it like a Unity game, e.g. instead of using the .NET WebRequest, WebClient etc you use a UnityWebRequest and use a Coroutine setup on a MonoBehaviour."  -> search for StartCoroutine()
+    - Encapsulate TextReport file/stringbuilder in a class. The class would have a data structure and Generate report method and get report text string method. (suggested by asterisk)
+
+
+===========================================
+
+CODE CLEANUP
+
+- check the tasklist for todo comments (View -> Tasklist); search for leftover todo's afterwards
+- remove unneeded/unused code; incl. vars in CatalogData
+- check for potential nullreference exception conditions
+- code cleanup:
+    - unneeded usings
+    - unneeded return values
+    - unneeded $"" string
+    - unused parameters, especially those with default values
+	- public vs private; no internal
+    - uint -> int where possible
+    - string vs StringBuilder
+    - ' & ' and ' | ' => ' && ' and ' || '
+    - Comment consistency: not too much, not too little. Preferably not behind code.
+    - Method comments using /// with 'summary', 'remarks' and 'returns' tags. Each tag with text on one line.
+    - loglevel debug vs warning vs error
+    - coding conventions (https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions):
+        * Capitalization of methods, public fields/properties and constants; uncapitalize private fields, method parameters and local vars within methods.
+        * Capitalization of abbreviations and names:
+            * Code: URL -> Url, DLC -> Dlc, HTML -> Html, CSV -> Csv, but ID stays ID.
+            * Text: URL, DLC, HTML, CSV, ID, Steam, Workshop, GitHub, game version (with space).
+        * Comments end with a period. No comments behind code.
+        * Blank lines where appropriate, only one (except between properties/fields and first method and between methods).
+        * Spacing, naming consistency, etc.
+        * use string interpolation ($"{ string1 } { string2 }") for concatenating (search for +).
+
+
+===========================================
+
+RANDOM CODE IDEAS
+
+MacOS check
+        Application.platform == RuntimePlatform.OSXPlayer
+
+
+Subscription update date:
+        foreach (var modEntry in PluginManager.instance.GetPluginsInfo().Select(pi => new EntryData(pi))
+        { var updated = modEntry.updated; }
+
+
+Activate TLS 1.2; sadly doesn't work for .Net FW 3.5:
+
+        public const SslProtocols _Tls12 = (SslProtocols)0x00000C00;
+        public const SecurityProtocolType Tls12 = (SecurityProtocolType)_Tls12;
+        System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolTypeExtensions.Tls12;     // not recognized
+
+    * add this, still doesn't work:
+
+        namespace System.Security.Authentication
+        {
+            public static class SslProtocolsExtensions
+            {
+                public const SslProtocols Tls12 = (SslProtocols)0x00000C00;
+                public const SslProtocols Tls11 = (SslProtocols)0x00000300;
+            }
+        }
+
+        namespace System.Net
+        {
+            using System.Security.Authentication;
+
+            public static class SecurityProtocolTypeExtensions
+            {
+                public const SecurityProtocolType Tls12 = (SecurityProtocolType)SslProtocolsExtensions.Tls12;
+                public const SecurityProtocolType Tls11 = (SecurityProtocolType)SslProtocolsExtensions.Tls11;
+                public const SecurityProtocolType SystemDefault = (SecurityProtocolType)0;
+            }
+        }
+
+
+Get our own mod path:
+
+        public static string AssemblyDirectory
+        {
+            get
+            {
+                var pluginManager = PluginManager.instance;
+                var plugins = pluginManager.GetPluginsInfo();
+
+                foreach (var item in plugins)
+                {
+                    try
+                    {
+                        var instances = item.GetInstances<IUserMod>();
+                        if (!(instances.FirstOrDefault() is ChangeLoadingImageMod))
+                        {
+                            continue;
+                        }
+
+                        return item.modPath;
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                throw new Exception("Failed to find ChangeLoadingImage assembly!");
+            }
+        }
+
+
+Get mod path for any plugin:
+
+        private static string GetModPath()
+        {
+            PluginInfo pluginInfo = PluginManager.instance.GetPluginsInfo()
+                .FirstOrDefault(pi => pi.publishedFileID.AsUInt64 == SteamID);
+
+            return pluginInfo?.modPath;
+        }


### PR DESCRIPTION
#### With a great help from @chameleon-tbn side we've managed to create an update to the Compatibility Report mod.

I've create simple HTML report generator - template is based on T4 templating engine, can be swapped later with `StringBuilder` if you don't like this solution but currently it does its job pretty well and code is quite readable considering how much time it took to build a working thing.

This PR is based on your **v.0.8** branch, I've tried to implement most of todo's, either marked for 0.8 and some for 1.0, so options screen is now filled with configurable options, settings are saved into xml file (serialization it partially based on TM:PE one), for @chameleon-tbn request I've built dedicated UI for CR maintenance so all you logging to the Updater log is also logged to a nice dialog, shows the progress, errors, etc. I tried to follow you code conventions and make it as simple and understandable as possible. 

I didn't want to break anything in the Updater and Crawler code since I've had to learn how things work, so all the updater and crawler related code remained unchanged but I marked no longer used methods as `obsolete` and modified version was created (with progress monitoring and UI support) which should help figuring out what was changed. As you can see, not much has changed.


_I'm not sure if todo.txt file should be included in this PR but as I said, I took 0.8 branch as a base so some of your work is included._

Oh, and a zip file if you have some time and want to try it in action: [CompatibilityReport_v.0.8-rc1.zip](https://github.com/Finwickle/CompatibilityReport/files/9209590/CompatibilityReport_v.0.8-rc1.zip)

